### PR TITLE
use getWatched method from boxrec-requests

### DIFF
--- a/docs/classes/boxrec.html
+++ b/docs/classes/boxrec.html
@@ -753,7 +753,7 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists all boxers that are watched</p>
+									<p>Lists all boxers that are watched by the user</p>
 								</div>
 							</div>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="boxrecpagewatchrow.html" class="tsd-signature-type">BoxrecPageWatchRow</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/request": "^2.47.0",
     "@types/request-promise": "^4.1.41",
     "boxrec-mocks": "1.1.0",
-    "boxrec-requests": "4.1.0",
+    "boxrec-requests": "4.2.0",
     "cheerio": "^1.0.0-rc.2",
     "coveralls": "^3.0.0",
     "husky": "1.0.0-rc.13",

--- a/src/boxrec.class.spec.ts
+++ b/src/boxrec.class.spec.ts
@@ -1,3 +1,4 @@
+import {BoxrecRequests} from "boxrec-requests";
 import * as fs from "fs";
 import * as rp from "request-promise";
 import {Cookie} from "tough-cookie";
@@ -412,6 +413,18 @@ describe("class Boxrec", () => {
         it("should throw an error if the boxer does appear in the list", async () => {
             jest.spyOn(BoxrecPageWatch.prototype, "checkForBoxerInList").mockReturnValueOnce(true);
             await expect(boxrec.unwatch(352)).rejects.toThrowError("Boxer appears in list after being removed");
+        });
+
+    });
+
+    describe("method getWatched", () => {
+
+        it("should return a list of watched boxers", async () => {
+            const spy: SpyInstance = jest.spyOn(BoxrecRequests, "getWatched");
+            const spyList: SpyInstance = jest.spyOn(BoxrecPageWatch.prototype, "list");
+            await boxrec.getWatched();
+            expect(spy).toHaveBeenCalled();
+            expect(spyList).toHaveBeenCalled();
         });
 
     });

--- a/src/boxrec.class.ts
+++ b/src/boxrec.class.ts
@@ -306,13 +306,13 @@ class Boxrec {
     }
 
     /**
-     * Lists all boxers that are watched
+     * Lists all boxers that are watched by the user
      * @returns {Promise<BoxrecPageWatchRow>}
      */
     async getWatched(): Promise<BoxrecPageWatchRow[]> {
         this.checkIfLoggedIntoBoxRec();
 
-        const boxrecPageBody: RequestResponse["body"] = await BoxrecRequests.watch(this._cookieJar, 0);
+        const boxrecPageBody: RequestResponse["body"] = await BoxrecRequests.getWatched(this._cookieJar);
         return new BoxrecPageWatch(boxrecPageBody).list();
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,9 +711,9 @@ boxrec-mocks@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/boxrec-mocks/-/boxrec-mocks-1.1.0.tgz#e957e823a070f49db7b30b11b24a31f6bbfaae50"
 
-boxrec-requests@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/boxrec-requests/-/boxrec-requests-4.1.0.tgz#c55468465f281eefac101d10504716c09c9ac6fe"
+boxrec-requests@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/boxrec-requests/-/boxrec-requests-4.2.0.tgz#dbfbce11ee2d13f59cfae96835e14aa66bcc6b6e"
   dependencies:
     cheerio "^1.0.0-rc.2"
     request-promise "^4.2.2"


### PR DESCRIPTION
Instead of doing a workaround, use the now support `getWatched` method from `boxrec-requests`