### PR TITLE
Fixed KOs, changed from percentage to number

### DIFF
--- a/docs/classes/boxrec.html
+++ b/docs/classes/boxrec.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L64">boxrec.class.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L64">boxrec.class.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L78">boxrec.class.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L78">boxrec.class.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L90">boxrec.class.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L90">boxrec.class.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L99">boxrec.class.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L99">boxrec.class.ts:99</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L111">boxrec.class.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L111">boxrec.class.ts:111</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -302,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L123">boxrec.class.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L123">boxrec.class.ts:123</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -336,7 +336,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L136">boxrec.class.ts:136</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L136">boxrec.class.ts:136</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -376,7 +376,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L150">boxrec.class.ts:150</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L150">boxrec.class.ts:150</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -416,7 +416,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L393">boxrec.class.ts:393</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L393">boxrec.class.ts:393</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -480,7 +480,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L166">boxrec.class.ts:166</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L166">boxrec.class.ts:166</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -526,7 +526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L203">boxrec.class.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L203">boxrec.class.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -566,7 +566,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L218">boxrec.class.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L218">boxrec.class.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -607,7 +607,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L232">boxrec.class.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L232">boxrec.class.ts:232</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -647,7 +647,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L246">boxrec.class.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L246">boxrec.class.ts:246</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -687,7 +687,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L260">boxrec.class.ts:260</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L260">boxrec.class.ts:260</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -721,7 +721,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L273">boxrec.class.ts:273</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L273">boxrec.class.ts:273</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -758,7 +758,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L285">boxrec.class.ts:285</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L285">boxrec.class.ts:285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -786,7 +786,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L54">boxrec.class.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L54">boxrec.class.ts:54</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -827,7 +827,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L299">boxrec.class.ts:299</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L299">boxrec.class.ts:299</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -868,7 +868,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L311">boxrec.class.ts:311</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L311">boxrec.class.ts:311</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -899,7 +899,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec.class.ts#L328">boxrec.class.ts:328</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec.class.ts#L328">boxrec.class.ts:328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/boxreccommonlinks.html
+++ b/docs/classes/boxreccommonlinks.html
@@ -98,7 +98,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-links.ts#L20">boxrec-common-tables/boxrec-common-links.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-links.ts#L20">boxrec-common-tables/boxrec-common-links.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -135,7 +135,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-links.ts#L34">boxrec-common-tables/boxrec-common-links.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-links.ts#L34">boxrec-common-tables/boxrec-common-links.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/boxreccommontablescolumnsclass.html
+++ b/docs/classes/boxreccommontablescolumnsclass.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L56">boxrec-common-tables/boxrec-common-tables-columns.class.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L56">boxrec-common-tables/boxrec-common-tables-columns.class.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L108">boxrec-common-tables/boxrec-common-tables-columns.class.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L108">boxrec-common-tables/boxrec-common-tables-columns.class.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L170">boxrec-common-tables/boxrec-common-tables-columns.class.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L170">boxrec-common-tables/boxrec-common-tables-columns.class.ts:170</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -180,7 +180,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L272">boxrec-common-tables/boxrec-common-tables-columns.class.ts:272</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L272">boxrec-common-tables/boxrec-common-tables-columns.class.ts:272</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -206,7 +206,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L293">boxrec-common-tables/boxrec-common-tables-columns.class.ts:293</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L293">boxrec-common-tables/boxrec-common-tables-columns.class.ts:293</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecdateevent.html
+++ b/docs/classes/boxrecdateevent.html
@@ -141,7 +141,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.date.event.ts#L8">boxrec-pages/date/boxrec.date.event.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.date.event.ts#L8">boxrec-pages/date/boxrec.date.event.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -165,7 +165,7 @@
 						<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#_">$</a></p>
 						<p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#bouts">bouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L21">boxrec-pages/event/boxrec.event.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L21">boxrec-pages/event/boxrec.event.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpageeventboutrow.html" class="tsd-signature-type">BoxrecPageEventBoutRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.date.event.ts#L15">boxrec-pages/date/boxrec.date.event.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.date.event.ts#L15">boxrec-pages/date/boxrec.date.event.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -218,7 +218,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#location">location</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L25">boxrec-pages/event/boxrec.event.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L25">boxrec-pages/event/boxrec.event.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecboutlocation.html" class="tsd-signature-type">BoxrecBoutLocation</a></h4>
@@ -236,7 +236,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#matchmakers">matchmakers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L48">boxrec-pages/event/boxrec.event.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L48">boxrec-pages/event/boxrec.event.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -254,7 +254,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#numberofbouts">numberOfBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -272,7 +272,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#promoters">promoters</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L68">boxrec-pages/event/boxrec.event.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L68">boxrec-pages/event/boxrec.event.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecpromoter.html" class="tsd-signature-type">BoxrecPromoter</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -293,7 +293,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getpeopletable">getPeopleTable</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L147">boxrec-pages/event/boxrec.event.ts:147</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L147">boxrec-pages/event/boxrec.event.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>
@@ -311,7 +311,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#parsebouts">parseBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -329,7 +329,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parseeventdata">parseEventData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L151">boxrec-pages/event/boxrec.event.ts:151</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L151">boxrec-pages/event/boxrec.event.ts:151</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -353,7 +353,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parselocation">parseLocation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.date.event.ts#L19">boxrec-pages/date/boxrec.date.event.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.date.event.ts#L19">boxrec-pages/date/boxrec.date.event.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -371,7 +371,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parsematchmakers">parseMatchmakers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.date.event.ts#L27">boxrec-pages/date/boxrec.date.event.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.date.event.ts#L27">boxrec-pages/date/boxrec.date.event.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -394,7 +394,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parsepromoters">parsePromoters</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.date.event.ts#L35">boxrec-pages/date/boxrec.date.event.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.date.event.ts#L35">boxrec-pages/date/boxrec.date.event.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -417,7 +417,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -441,7 +441,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getlocationinformation">getLocationInformation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L182">boxrec-pages/event/boxrec.event.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L182">boxrec-pages/event/boxrec.event.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -465,7 +465,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getvenueinformation">getVenueInformation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L222">boxrec-pages/event/boxrec.event.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L222">boxrec-pages/event/boxrec.event.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecevent.html
+++ b/docs/classes/boxrecevent.html
@@ -148,7 +148,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -171,7 +171,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L21">boxrec-pages/event/boxrec.event.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L21">boxrec-pages/event/boxrec.event.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpageeventboutrow.html" class="tsd-signature-type">BoxrecPageEventBoutRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -205,7 +205,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L25">boxrec-pages/event/boxrec.event.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L25">boxrec-pages/event/boxrec.event.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecboutlocation.html" class="tsd-signature-type">BoxrecBoutLocation</a></h4>
@@ -222,7 +222,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L48">boxrec-pages/event/boxrec.event.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L48">boxrec-pages/event/boxrec.event.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -240,7 +240,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#numberofbouts">numberOfBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -257,7 +257,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L68">boxrec-pages/event/boxrec.event.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L68">boxrec-pages/event/boxrec.event.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecpromoter.html" class="tsd-signature-type">BoxrecPromoter</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L147">boxrec-pages/event/boxrec.event.ts:147</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L147">boxrec-pages/event/boxrec.event.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#parsebouts">parseBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -312,7 +312,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L151">boxrec-pages/event/boxrec.event.ts:151</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L151">boxrec-pages/event/boxrec.event.ts:151</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L168">boxrec-pages/event/boxrec.event.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L168">boxrec-pages/event/boxrec.event.ts:168</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -352,7 +352,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L173">boxrec-pages/event/boxrec.event.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L173">boxrec-pages/event/boxrec.event.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -369,7 +369,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L178">boxrec-pages/event/boxrec.event.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L178">boxrec-pages/event/boxrec.event.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -387,7 +387,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -410,7 +410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L182">boxrec-pages/event/boxrec.event.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L182">boxrec-pages/event/boxrec.event.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -433,7 +433,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L222">boxrec-pages/event/boxrec.event.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L222">boxrec-pages/event/boxrec.event.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpagechampions.html
+++ b/docs/classes/boxrecpagechampions.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L43">boxrec-pages/champions/boxrec.page.champions.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L43">boxrec-pages/champions/boxrec.page.champions.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L49">boxrec-pages/champions/boxrec.page.champions.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L49">boxrec-pages/champions/boxrec.page.champions.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L53">boxrec-pages/champions/boxrec.page.champions.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L53">boxrec-pages/champions/boxrec.page.champions.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecchampionsbyweightdivision.html" class="tsd-signature-type">BoxrecChampionsByWeightDivision</a></h4>
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L65">boxrec-pages/champions/boxrec.page.champions.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L65">boxrec-pages/champions/boxrec.page.champions.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecunformattedchampions.html" class="tsd-signature-type">BoxrecUnformattedChampions</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -183,7 +183,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L69">boxrec-pages/champions/boxrec.page.champions.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L69">boxrec-pages/champions/boxrec.page.champions.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecchampionsoutput.html" class="tsd-signature-type">BoxrecChampionsOutput</a></h4>

--- a/docs/classes/boxrecpagedate.html
+++ b/docs/classes/boxrecpagedate.html
@@ -129,7 +129,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageschedulecommon.html">BoxrecPageScheduleCommon</a>.<a href="boxrecpageschedulecommon.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.page.date.ts#L11">boxrec-pages/date/boxrec.page.date.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.page.date.ts#L11">boxrec-pages/date/boxrec.page.date.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -152,7 +152,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpageschedulecommon.html">BoxrecPageScheduleCommon</a>.<a href="boxrecpageschedulecommon.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.page.date.ts#L11">boxrec-pages/date/boxrec.page.date.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.page.date.ts#L11">boxrec-pages/date/boxrec.page.date.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.page.date.ts#L18">boxrec-pages/date/boxrec.page.date.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.page.date.ts#L18">boxrec-pages/date/boxrec.page.date.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecdateevent.html" class="tsd-signature-type">BoxrecDateEvent</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.page.date.ts#L22">boxrec-pages/date/boxrec.page.date.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.page.date.ts#L22">boxrec-pages/date/boxrec.page.date.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecdateoutput.html" class="tsd-signature-type">BoxrecDateOutput</a></h4>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageschedulecommon.html">BoxrecPageScheduleCommon</a>.<a href="boxrecpageschedulecommon.html#parse">parse</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L12">boxrec-pages/schedule/boxrec.page.schedule.common.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L12">boxrec-pages/schedule/boxrec.page.schedule.common.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>

--- a/docs/classes/boxrecpageevent.html
+++ b/docs/classes/boxrecpageevent.html
@@ -152,7 +152,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L12">boxrec-pages/event/boxrec.page.event.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L12">boxrec-pages/event/boxrec.page.event.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -176,7 +176,7 @@
 						<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#_">$</a></p>
 						<p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#bouts">bouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L21">boxrec-pages/event/boxrec.event.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L21">boxrec-pages/event/boxrec.event.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpageeventboutrow.html" class="tsd-signature-type">BoxrecPageEventBoutRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L19">boxrec-pages/event/boxrec.page.event.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L19">boxrec-pages/event/boxrec.page.event.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L28">boxrec-pages/event/boxrec.page.event.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L28">boxrec-pages/event/boxrec.page.event.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L38">boxrec-pages/event/boxrec.page.event.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L38">boxrec-pages/event/boxrec.page.event.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L46">boxrec-pages/event/boxrec.page.event.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L46">boxrec-pages/event/boxrec.page.event.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -288,7 +288,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L69">boxrec-pages/event/boxrec.page.event.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L69">boxrec-pages/event/boxrec.page.event.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -306,7 +306,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#location">location</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L83">boxrec-pages/event/boxrec.page.event.ts:83</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L83">boxrec-pages/event/boxrec.page.event.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecboutlocation.html" class="tsd-signature-type">BoxrecBoutLocation</a></h4>
@@ -324,7 +324,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#matchmakers">matchmakers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L120">boxrec-pages/event/boxrec.page.event.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L120">boxrec-pages/event/boxrec.page.event.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -342,7 +342,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#numberofbouts">numberOfBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L144">boxrec-pages/event/boxrec.page.event.ts:144</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L144">boxrec-pages/event/boxrec.page.event.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreceventoutput.html" class="tsd-signature-type">BoxrecEventOutput</a></h4>
@@ -377,7 +377,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#promoters">promoters</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L68">boxrec-pages/event/boxrec.event.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L68">boxrec-pages/event/boxrec.event.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecpromoter.html" class="tsd-signature-type">BoxrecPromoter</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -394,7 +394,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L160">boxrec-pages/event/boxrec.page.event.ts:160</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L160">boxrec-pages/event/boxrec.page.event.ts:160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -415,7 +415,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getpeopletable">getPeopleTable</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L147">boxrec-pages/event/boxrec.event.ts:147</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L147">boxrec-pages/event/boxrec.event.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>
@@ -433,7 +433,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#parsebouts">parseBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -451,7 +451,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parseeventdata">parseEventData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L151">boxrec-pages/event/boxrec.event.ts:151</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L151">boxrec-pages/event/boxrec.event.ts:151</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -475,7 +475,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parselocation">parseLocation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L168">boxrec-pages/event/boxrec.event.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L168">boxrec-pages/event/boxrec.event.ts:168</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -493,7 +493,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parsematchmakers">parseMatchmakers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L173">boxrec-pages/event/boxrec.event.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L173">boxrec-pages/event/boxrec.event.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -511,7 +511,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parsepromoters">parsePromoters</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L140">boxrec-pages/event/boxrec.page.event.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L140">boxrec-pages/event/boxrec.page.event.ts:140</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -529,7 +529,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -553,7 +553,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getlocationinformation">getLocationInformation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L182">boxrec-pages/event/boxrec.event.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L182">boxrec-pages/event/boxrec.event.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -577,7 +577,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getvenueinformation">getVenueInformation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L222">boxrec-pages/event/boxrec.event.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L222">boxrec-pages/event/boxrec.event.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpageeventbout.html
+++ b/docs/classes/boxrecpageeventbout.html
@@ -178,7 +178,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L21">boxrec-pages/event/bout/boxrec.page.event.bout.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L21">boxrec-pages/event/bout/boxrec.page.event.bout.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -202,7 +202,7 @@
 						<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#_">$</a></p>
 						<p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L14">boxrec-pages/event/boxrec.event.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#bouts">bouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L21">boxrec-pages/event/boxrec.event.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L21">boxrec-pages/event/boxrec.event.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpageeventboutrow.html" class="tsd-signature-type">BoxrecPageEventBoutRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -238,7 +238,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#commission">commission</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L19">boxrec-pages/event/boxrec.page.event.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L19">boxrec-pages/event/boxrec.page.event.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -259,7 +259,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#date">date</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L28">boxrec-pages/event/bout/boxrec.page.event.bout.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L28">boxrec-pages/event/bout/boxrec.page.event.bout.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L84">boxrec-pages/event/bout/boxrec.page.event.bout.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L84">boxrec-pages/event/bout/boxrec.page.event.bout.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a>
@@ -300,7 +300,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#doctors">doctors</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L38">boxrec-pages/event/boxrec.page.event.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L38">boxrec-pages/event/boxrec.page.event.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L88">boxrec-pages/event/bout/boxrec.page.event.bout.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L88">boxrec-pages/event/bout/boxrec.page.event.bout.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L93">boxrec-pages/event/bout/boxrec.page.event.bout.ts:93</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L93">boxrec-pages/event/bout/boxrec.page.event.bout.ts:93</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -354,7 +354,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L97">boxrec-pages/event/bout/boxrec.page.event.bout.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L97">boxrec-pages/event/bout/boxrec.page.event.bout.ts:97</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span>
@@ -374,7 +374,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L101">boxrec-pages/event/bout/boxrec.page.event.bout.ts:101</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L101">boxrec-pages/event/bout/boxrec.page.event.bout.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L105">boxrec-pages/event/bout/boxrec.page.event.bout.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L105">boxrec-pages/event/bout/boxrec.page.event.bout.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boutpagelast6.html" class="tsd-signature-type">BoutPageLast6</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -408,7 +408,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L109">boxrec-pages/event/bout/boxrec.page.event.bout.ts:109</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L109">boxrec-pages/event/bout/boxrec.page.event.bout.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -428,7 +428,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L113">boxrec-pages/event/bout/boxrec.page.event.bout.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L113">boxrec-pages/event/bout/boxrec.page.event.bout.ts:113</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -448,7 +448,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L117">boxrec-pages/event/bout/boxrec.page.event.bout.ts:117</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L117">boxrec-pages/event/bout/boxrec.page.event.bout.ts:117</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -468,7 +468,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L121">boxrec-pages/event/bout/boxrec.page.event.bout.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L121">boxrec-pages/event/bout/boxrec.page.event.bout.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span>
@@ -488,7 +488,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L125">boxrec-pages/event/bout/boxrec.page.event.bout.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L125">boxrec-pages/event/bout/boxrec.page.event.bout.ts:125</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -505,7 +505,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L129">boxrec-pages/event/bout/boxrec.page.event.bout.ts:129</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L129">boxrec-pages/event/bout/boxrec.page.event.bout.ts:129</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../globals.html#stance" class="tsd-signature-type">Stance</a>
@@ -526,7 +526,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#id">id</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L46">boxrec-pages/event/boxrec.page.event.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L46">boxrec-pages/event/boxrec.page.event.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -547,7 +547,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#inspector">inspector</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L69">boxrec-pages/event/boxrec.page.event.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L69">boxrec-pages/event/boxrec.page.event.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -564,7 +564,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L133">boxrec-pages/event/bout/boxrec.page.event.bout.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L133">boxrec-pages/event/bout/boxrec.page.event.bout.ts:133</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecjudge.html" class="tsd-signature-type">BoxrecJudge</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -583,7 +583,7 @@
 								<p>Inherited from <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#location">location</a></p>
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#location">location</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L83">boxrec-pages/event/boxrec.page.event.ts:83</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L83">boxrec-pages/event/boxrec.page.event.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecboutlocation.html" class="tsd-signature-type">BoxrecBoutLocation</a></h4>
@@ -602,7 +602,7 @@
 								<p>Inherited from <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#matchmakers">matchmakers</a></p>
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#matchmakers">matchmakers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L120">boxrec-pages/event/boxrec.page.event.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L120">boxrec-pages/event/boxrec.page.event.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -620,7 +620,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#numberofbouts">numberOfBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -637,7 +637,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L173">boxrec-pages/event/bout/boxrec.page.event.bout.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L173">boxrec-pages/event/bout/boxrec.page.event.bout.ts:173</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -662,7 +662,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L182">boxrec-pages/event/bout/boxrec.page.event.bout.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L182">boxrec-pages/event/bout/boxrec.page.event.bout.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boutpageboutoutcome.html" class="tsd-signature-type">BoutPageBoutOutcome</a></h4>
@@ -680,7 +680,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#output">output</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L39">boxrec-pages/event/bout/boxrec.page.event.bout.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L39">boxrec-pages/event/bout/boxrec.page.event.bout.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreceventboutoutput.html" class="tsd-signature-type">BoxrecEventBoutOutput</a></h4>
@@ -698,7 +698,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#promoters">promoters</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L68">boxrec-pages/event/boxrec.event.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L68">boxrec-pages/event/boxrec.event.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecpromoter.html" class="tsd-signature-type">BoxrecPromoter</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -715,7 +715,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L186">boxrec-pages/event/bout/boxrec.page.event.bout.ts:186</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L186">boxrec-pages/event/bout/boxrec.page.event.bout.ts:186</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -735,7 +735,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L197">boxrec-pages/event/bout/boxrec.page.event.bout.ts:197</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L197">boxrec-pages/event/bout/boxrec.page.event.bout.ts:197</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -752,7 +752,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L203">boxrec-pages/event/bout/boxrec.page.event.bout.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L203">boxrec-pages/event/bout/boxrec.page.event.bout.ts:203</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -769,7 +769,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L208">boxrec-pages/event/bout/boxrec.page.event.bout.ts:208</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L208">boxrec-pages/event/bout/boxrec.page.event.bout.ts:208</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -789,7 +789,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L212">boxrec-pages/event/bout/boxrec.page.event.bout.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L212">boxrec-pages/event/bout/boxrec.page.event.bout.ts:212</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span>
@@ -809,7 +809,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L216">boxrec-pages/event/bout/boxrec.page.event.bout.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L216">boxrec-pages/event/bout/boxrec.page.event.bout.ts:216</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -826,7 +826,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L220">boxrec-pages/event/bout/boxrec.page.event.bout.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L220">boxrec-pages/event/bout/boxrec.page.event.bout.ts:220</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boutpagelast6.html" class="tsd-signature-type">BoutPageLast6</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -843,7 +843,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L224">boxrec-pages/event/bout/boxrec.page.event.bout.ts:224</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L224">boxrec-pages/event/bout/boxrec.page.event.bout.ts:224</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -863,7 +863,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L228">boxrec-pages/event/bout/boxrec.page.event.bout.ts:228</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L228">boxrec-pages/event/bout/boxrec.page.event.bout.ts:228</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -883,7 +883,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L232">boxrec-pages/event/bout/boxrec.page.event.bout.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L232">boxrec-pages/event/bout/boxrec.page.event.bout.ts:232</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -903,7 +903,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L236">boxrec-pages/event/bout/boxrec.page.event.bout.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L236">boxrec-pages/event/bout/boxrec.page.event.bout.ts:236</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span>
@@ -923,7 +923,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L240">boxrec-pages/event/bout/boxrec.page.event.bout.ts:240</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L240">boxrec-pages/event/bout/boxrec.page.event.bout.ts:240</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -940,7 +940,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L244">boxrec-pages/event/bout/boxrec.page.event.bout.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L244">boxrec-pages/event/bout/boxrec.page.event.bout.ts:244</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../globals.html#stance" class="tsd-signature-type">Stance</a>
@@ -961,7 +961,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#television">television</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L160">boxrec-pages/event/boxrec.page.event.ts:160</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L160">boxrec-pages/event/boxrec.page.event.ts:160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -978,7 +978,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L248">boxrec-pages/event/bout/boxrec.page.event.bout.ts:248</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L248">boxrec-pages/event/bout/boxrec.page.event.bout.ts:248</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrectitles.html" class="tsd-signature-type">BoxrecTitles</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -999,7 +999,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getpeopletable">getPeopleTable</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L254">boxrec-pages/event/bout/boxrec.page.event.bout.ts:254</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts#L254">boxrec-pages/event/bout/boxrec.page.event.bout.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>
@@ -1017,7 +1017,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#parsebouts">parseBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1035,7 +1035,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parseeventdata">parseEventData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L151">boxrec-pages/event/boxrec.event.ts:151</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L151">boxrec-pages/event/boxrec.event.ts:151</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1059,7 +1059,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parselocation">parseLocation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L168">boxrec-pages/event/boxrec.event.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L168">boxrec-pages/event/boxrec.event.ts:168</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -1077,7 +1077,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parsematchmakers">parseMatchmakers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L173">boxrec-pages/event/boxrec.event.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L173">boxrec-pages/event/boxrec.event.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -1096,7 +1096,7 @@
 								<p>Inherited from <a href="boxrecpageevent.html">BoxrecPageEvent</a>.<a href="boxrecpageevent.html#parsepromoters">parsePromoters</a></p>
 								<p>Overrides <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#parsepromoters">parsePromoters</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.ts#L140">boxrec-pages/event/boxrec.page.event.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.ts#L140">boxrec-pages/event/boxrec.page.event.ts:140</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -1114,7 +1114,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1138,7 +1138,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getlocationinformation">getLocationInformation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L182">boxrec-pages/event/boxrec.event.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L182">boxrec-pages/event/boxrec.event.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1162,7 +1162,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecevent.html">BoxrecEvent</a>.<a href="boxrecevent.html#getvenueinformation">getVenueInformation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.ts#L222">boxrec-pages/event/boxrec.event.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.ts#L222">boxrec-pages/event/boxrec.event.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpageeventboutrow.html
+++ b/docs/classes/boxrecpageeventboutrow.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L12">boxrec-pages/event/boxrec.page.event.bout.row.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L12">boxrec-pages/event/boxrec.page.event.bout.row.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L20">boxrec-pages/event/boxrec.page.event.bout.row.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L20">boxrec-pages/event/boxrec.page.event.bout.row.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a>
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L24">boxrec-pages/event/boxrec.page.event.bout.row.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L24">boxrec-pages/event/boxrec.page.event.bout.row.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L28">boxrec-pages/event/boxrec.page.event.bout.row.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L28">boxrec-pages/event/boxrec.page.event.bout.row.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L35">boxrec-pages/event/boxrec.page.event.bout.row.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L35">boxrec-pages/event/boxrec.page.event.bout.row.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -220,7 +220,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L39">boxrec-pages/event/boxrec.page.event.bout.row.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L39">boxrec-pages/event/boxrec.page.event.bout.row.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -240,7 +240,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L48">boxrec-pages/event/boxrec.page.event.bout.row.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L48">boxrec-pages/event/boxrec.page.event.bout.row.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreceventlinks.html" class="tsd-signature-type">BoxrecEventLinks</a></h4>
@@ -257,7 +257,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L59">boxrec-pages/event/boxrec.page.event.bout.row.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L59">boxrec-pages/event/boxrec.page.event.bout.row.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L63">boxrec-pages/event/boxrec.page.event.bout.row.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L63">boxrec-pages/event/boxrec.page.event.bout.row.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -294,7 +294,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L67">boxrec-pages/event/boxrec.page.event.bout.row.ts:67</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L67">boxrec-pages/event/boxrec.page.event.bout.row.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a>
@@ -314,7 +314,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L75">boxrec-pages/event/boxrec.page.event.bout.row.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L75">boxrec-pages/event/boxrec.page.event.bout.row.ts:75</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L83">boxrec-pages/event/boxrec.page.event.bout.row.ts:83</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L83">boxrec-pages/event/boxrec.page.event.bout.row.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -354,7 +354,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L87">boxrec-pages/event/boxrec.page.event.bout.row.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L87">boxrec-pages/event/boxrec.page.event.bout.row.ts:87</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -371,7 +371,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L91">boxrec-pages/event/boxrec.page.event.bout.row.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L91">boxrec-pages/event/boxrec.page.event.bout.row.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L95">boxrec-pages/event/boxrec.page.event.bout.row.ts:95</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L95">boxrec-pages/event/boxrec.page.event.bout.row.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -405,7 +405,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L99">boxrec-pages/event/boxrec.page.event.bout.row.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.page.event.bout.row.ts#L99">boxrec-pages/event/boxrec.page.event.bout.row.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>

--- a/docs/classes/boxrecpageeventcommonrow.html
+++ b/docs/classes/boxrecpageeventcommonrow.html
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L7">boxrec-pages/location/event/boxrec.page.event.common.row.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L7">boxrec-pages/location/event/boxrec.page.event.common.row.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">$<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CheerioStatic</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L7">boxrec-pages/location/event/boxrec.page.event.common.row.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L7">boxrec-pages/location/event/boxrec.page.event.common.row.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L13">boxrec-pages/location/event/boxrec.page.event.common.row.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L13">boxrec-pages/location/event/boxrec.page.event.common.row.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L31">boxrec-pages/location/event/boxrec.page.event.common.row.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L31">boxrec-pages/location/event/boxrec.page.event.common.row.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L39">boxrec-pages/location/event/boxrec.page.event.common.row.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L39">boxrec-pages/location/event/boxrec.page.event.common.row.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>
@@ -227,7 +227,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L44">boxrec-pages/location/event/boxrec.page.event.common.row.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L44">boxrec-pages/location/event/boxrec.page.event.common.row.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/boxrecpagelists.html
+++ b/docs/classes/boxrecpagelists.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L6">boxrec-common-tables/boxrec-page-lists.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L6">boxrec-common-tables/boxrec-page-lists.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">$<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CheerioStatic</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L6">boxrec-common-tables/boxrec-page-lists.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L6">boxrec-common-tables/boxrec-page-lists.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L12">boxrec-common-tables/boxrec-page-lists.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L12">boxrec-common-tables/boxrec-page-lists.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L16">boxrec-common-tables/boxrec-page-lists.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L16">boxrec-common-tables/boxrec-page-lists.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L21">boxrec-common-tables/boxrec-page-lists.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L21">boxrec-common-tables/boxrec-page-lists.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/boxrecpagelocationevent.html
+++ b/docs/classes/boxrecpagelocationevent.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L6">boxrec-common-tables/boxrec-page-lists.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L6">boxrec-common-tables/boxrec-page-lists.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.ts#L10">boxrec-pages/location/event/boxrec.page.location.event.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.ts#L10">boxrec-pages/location/event/boxrec.page.location.event.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.ts#L12">boxrec-pages/location/event/boxrec.page.location.event.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.ts#L12">boxrec-pages/location/event/boxrec.page.location.event.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpagelocationeventrow.html" class="tsd-signature-type">BoxrecPageLocationEventRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.ts#L16">boxrec-pages/location/event/boxrec.page.location.event.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.ts#L16">boxrec-pages/location/event/boxrec.page.location.event.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#numberofpages">numberOfPages</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L12">boxrec-common-tables/boxrec-page-lists.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L12">boxrec-common-tables/boxrec-page-lists.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#getnumberofpages">getNumberOfPages</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L16">boxrec-common-tables/boxrec-page-lists.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L16">boxrec-common-tables/boxrec-page-lists.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#gettabledata">getTableData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L21">boxrec-common-tables/boxrec-page-lists.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L21">boxrec-common-tables/boxrec-page-lists.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/boxrecpagelocationeventrow.html
+++ b/docs/classes/boxrecpagelocationeventrow.html
@@ -127,7 +127,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L18">boxrec-pages/location/event/boxrec.page.location.event.row.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L18">boxrec-pages/location/event/boxrec.page.location.event.row.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -150,7 +150,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L9">boxrec-pages/location/event/boxrec.page.location.event.row.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L9">boxrec-pages/location/event/boxrec.page.location.event.row.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L26">boxrec-pages/location/event/boxrec.page.location.event.row.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L26">boxrec-pages/location/event/boxrec.page.location.event.row.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L30">boxrec-pages/location/event/boxrec.page.location.event.row.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L30">boxrec-pages/location/event/boxrec.page.location.event.row.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -201,7 +201,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L34">boxrec-pages/location/event/boxrec.page.location.event.row.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L34">boxrec-pages/location/event/boxrec.page.location.event.row.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -221,7 +221,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L38">boxrec-pages/location/event/boxrec.page.location.event.row.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L38">boxrec-pages/location/event/boxrec.page.location.event.row.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#venue">venue</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L13">boxrec-pages/location/event/boxrec.page.event.common.row.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L13">boxrec-pages/location/event/boxrec.page.event.common.row.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -260,7 +260,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#getcolumndata">getColumnData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L31">boxrec-pages/location/event/boxrec.page.event.common.row.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L31">boxrec-pages/location/event/boxrec.page.event.common.row.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -287,7 +287,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#getvenuecolumndata">getVenueColumnData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L11">boxrec-pages/location/event/boxrec.page.location.event.row.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L11">boxrec-pages/location/event/boxrec.page.location.event.row.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>
@@ -305,7 +305,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#hasmorecolumns">hasMoreColumns</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L16">boxrec-pages/location/event/boxrec.page.location.event.row.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.location.event.row.ts#L16">boxrec-pages/location/event/boxrec.page.location.event.row.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/boxrecpagelocationpeople.html
+++ b/docs/classes/boxrecpagelocationpeople.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L6">boxrec-common-tables/boxrec-page-lists.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L6">boxrec-common-tables/boxrec-page-lists.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.ts#L11">boxrec-pages/location/people/boxrec.page.location.people.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.ts#L11">boxrec-pages/location/people/boxrec.page.location.people.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.ts#L13">boxrec-pages/location/people/boxrec.page.location.people.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.ts#L13">boxrec-pages/location/people/boxrec.page.location.people.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpagelocationpeoplerow.html" class="tsd-signature-type">BoxrecPageLocationPeopleRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -190,7 +190,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#numberofpages">numberOfPages</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L12">boxrec-common-tables/boxrec-page-lists.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L12">boxrec-common-tables/boxrec-page-lists.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.ts#L17">boxrec-pages/location/people/boxrec.page.location.people.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.ts#L17">boxrec-pages/location/people/boxrec.page.location.people.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#getnumberofpages">getNumberOfPages</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L16">boxrec-common-tables/boxrec-page-lists.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L16">boxrec-common-tables/boxrec-page-lists.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#gettabledata">getTableData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L21">boxrec-common-tables/boxrec-page-lists.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L21">boxrec-common-tables/boxrec-page-lists.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/boxrecpagelocationpeoplerow.html
+++ b/docs/classes/boxrecpagelocationpeoplerow.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L9">boxrec-pages/location/people/boxrec.page.location.people.row.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L9">boxrec-pages/location/people/boxrec.page.location.people.row.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L17">boxrec-pages/location/people/boxrec.page.location.people.row.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L17">boxrec-pages/location/people/boxrec.page.location.people.row.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L22">boxrec-pages/location/people/boxrec.page.location.people.row.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L22">boxrec-pages/location/people/boxrec.page.location.people.row.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a>
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L26">boxrec-pages/location/people/boxrec.page.location.people.row.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L26">boxrec-pages/location/people/boxrec.page.location.people.row.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L35">boxrec-pages/location/people/boxrec.page.location.people.row.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L35">boxrec-pages/location/people/boxrec.page.location.people.row.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -213,7 +213,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L39">boxrec-pages/location/people/boxrec.page.location.people.row.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L39">boxrec-pages/location/people/boxrec.page.location.people.row.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -230,7 +230,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L43">boxrec-pages/location/people/boxrec.page.location.people.row.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L43">boxrec-pages/location/people/boxrec.page.location.people.row.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -247,7 +247,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L48">boxrec-pages/location/people/boxrec.page.location.people.row.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L48">boxrec-pages/location/people/boxrec.page.location.people.row.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L52">boxrec-pages/location/people/boxrec.page.location.people.row.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.page.location.people.row.ts#L52">boxrec-pages/location/people/boxrec.page.location.people.row.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">"male"</span>

--- a/docs/classes/boxrecpageprofile.html
+++ b/docs/classes/boxrecpageprofile.html
@@ -144,7 +144,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L11">boxrec-pages/profile/boxrec.page.profile.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L11">boxrec-pages/profile/boxrec.page.profile.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -167,7 +167,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L11">boxrec-pages/profile/boxrec.page.profile.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L11">boxrec-pages/profile/boxrec.page.profile.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -256,7 +256,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -281,7 +281,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -303,7 +303,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -342,7 +342,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -364,7 +364,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -387,7 +387,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -421,7 +421,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpageprofileboxer.html
+++ b/docs/classes/boxrecpageprofileboxer.html
@@ -157,7 +157,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L16">boxrec-pages/profile/boxrec.page.profile.boxer.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L16">boxrec-pages/profile/boxrec.page.profile.boxer.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -180,7 +180,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L16">boxrec-pages/profile/boxrec.page.profile.boxer.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L16">boxrec-pages/profile/boxrec.page.profile.boxer.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L27">boxrec-pages/profile/boxrec.page.profile.boxer.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L27">boxrec-pages/profile/boxrec.page.profile.boxer.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -222,7 +222,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L45">boxrec-pages/profile/boxrec.page.profile.boxer.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L45">boxrec-pages/profile/boxrec.page.profile.boxer.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -248,7 +248,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthname">birthName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -274,7 +274,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthplace">birthPlace</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -296,7 +296,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L60">boxrec-pages/profile/boxrec.page.profile.boxer.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L60">boxrec-pages/profile/boxrec.page.profile.boxer.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L82">boxrec-pages/profile/boxrec.page.profile.boxer.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L82">boxrec-pages/profile/boxrec.page.profile.boxer.ts:82</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -351,7 +351,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L91">boxrec-pages/profile/boxrec.page.profile.boxer.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L91">boxrec-pages/profile/boxrec.page.profile.boxer.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -376,7 +376,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L106">boxrec-pages/profile/boxrec.page.profile.boxer.ts:106</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L106">boxrec-pages/profile/boxrec.page.profile.boxer.ts:106</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -403,7 +403,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#globalid">globalId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -428,7 +428,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L121">boxrec-pages/profile/boxrec.page.profile.boxer.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L121">boxrec-pages/profile/boxrec.page.profile.boxer.ts:121</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -455,7 +455,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L130">boxrec-pages/profile/boxrec.page.profile.boxer.ts:130</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L130">boxrec-pages/profile/boxrec.page.profile.boxer.ts:130</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -482,7 +482,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#metadata">metadata</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -508,7 +508,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#name">name</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -530,7 +530,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L157">boxrec-pages/profile/boxrec.page.profile.boxer.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L157">boxrec-pages/profile/boxrec.page.profile.boxer.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -555,7 +555,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L171">boxrec-pages/profile/boxrec.page.profile.boxer.ts:171</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L171">boxrec-pages/profile/boxrec.page.profile.boxer.ts:171</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -578,7 +578,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#otherinfo">otherInfo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -600,7 +600,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L181">boxrec-pages/profile/boxrec.page.profile.boxer.ts:181</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L181">boxrec-pages/profile/boxrec.page.profile.boxer.ts:181</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecprofileboxeroutput.html" class="tsd-signature-type">BoxrecProfileBoxerOutput</a></h4>
@@ -618,7 +618,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#picture">picture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -635,7 +635,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L217">boxrec-pages/profile/boxrec.page.profile.boxer.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L217">boxrec-pages/profile/boxrec.page.profile.boxer.ts:217</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -660,7 +660,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L242">boxrec-pages/profile/boxrec.page.profile.boxer.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L242">boxrec-pages/profile/boxrec.page.profile.boxer.ts:242</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -686,7 +686,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L264">boxrec-pages/profile/boxrec.page.profile.boxer.ts:264</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L264">boxrec-pages/profile/boxrec.page.profile.boxer.ts:264</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -712,7 +712,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#residence">residence</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -735,7 +735,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#role">role</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -758,7 +758,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L287">boxrec-pages/profile/boxrec.page.profile.boxer.ts:287</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L287">boxrec-pages/profile/boxrec.page.profile.boxer.ts:287</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -783,7 +783,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L302">boxrec-pages/profile/boxrec.page.profile.boxer.ts:302</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L302">boxrec-pages/profile/boxrec.page.profile.boxer.ts:302</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -809,7 +809,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#status">status</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -839,7 +839,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L315">boxrec-pages/profile/boxrec.page.profile.boxer.ts:315</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L315">boxrec-pages/profile/boxrec.page.profile.boxer.ts:315</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -864,7 +864,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L328">boxrec-pages/profile/boxrec.page.profile.boxer.ts:328</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L328">boxrec-pages/profile/boxrec.page.profile.boxer.ts:328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -886,7 +886,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L351">boxrec-pages/profile/boxrec.page.profile.boxer.ts:351</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts#L351">boxrec-pages/profile/boxrec.page.profile.boxer.ts:351</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -917,7 +917,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpageprofileboxerboutrow.html
+++ b/docs/classes/boxrecpageprofileboxerboutrow.html
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecprofilecommonrow.html">BoxrecProfileCommonRow</a>.<a href="boxrecprofilecommonrow.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L8">boxrec-pages/profile/boxrec.profile.common.row.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L8">boxrec-pages/profile/boxrec.profile.common.row.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecprofilecommonrow.html">BoxrecProfileCommonRow</a>.<a href="boxrecprofilecommonrow.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L11">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L11">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L17">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L17">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L28">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L28">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L36">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L36">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -245,7 +245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L41">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L41">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -262,7 +262,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L45">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L45">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecjudge.html" class="tsd-signature-type">BoxrecJudge</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -280,7 +280,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecprofilecommonrow.html">BoxrecProfileCommonRow</a>.<a href="boxrecprofilecommonrow.html#links">links</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L15">boxrec-pages/profile/boxrec.profile.common.row.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L15">boxrec-pages/profile/boxrec.profile.common.row.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecgenerallinks.html" class="tsd-signature-type">BoxrecGeneralLinks</a></h4>
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L55">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L55">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecprofileboutlocation.html" class="tsd-signature-type">BoxrecProfileBoutLocation</a></h4>
@@ -314,7 +314,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L69">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L69">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L73">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L73">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -351,7 +351,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L77">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L77">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a></h4>
@@ -368,7 +368,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L81">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L81">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L85">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L85">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -405,7 +405,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L90">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L90">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:90</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">[</span><a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">, </span><a href="../enums/boxingboutoutcome.html" class="tsd-signature-type">BoxingBoutOutcome</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">, </span><a href="../enums/boxingboutoutcome.html" class="tsd-signature-type">BoxingBoutOutcome</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">]</span></h4>
@@ -422,7 +422,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L99">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L99">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -439,7 +439,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L103">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L103">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -456,7 +456,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L114">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:114</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L114">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:114</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -481,7 +481,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L122">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L122">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:122</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -498,7 +498,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L126">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L126">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:126</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -518,7 +518,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L130">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:130</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L130">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:130</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrectitles.html" class="tsd-signature-type">BoxrecTitles</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -539,7 +539,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecprofilecommonrow.html">BoxrecProfileCommonRow</a>.<a href="boxrecprofilecommonrow.html#parselinks">parseLinks</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L13">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L13">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>
@@ -556,7 +556,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L150">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:150</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts#L150">boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts:150</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/boxrecpageprofileeventrow.html
+++ b/docs/classes/boxrecpageprofileeventrow.html
@@ -127,7 +127,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L16">boxrec-pages/profile/boxrec.page.profile.event.row.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L16">boxrec-pages/profile/boxrec.page.profile.event.row.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L12">boxrec-pages/profile/boxrec.page.profile.event.row.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L12">boxrec-pages/profile/boxrec.page.profile.event.row.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L24">boxrec-pages/profile/boxrec.page.profile.event.row.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L24">boxrec-pages/profile/boxrec.page.profile.event.row.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L28">boxrec-pages/profile/boxrec.page.profile.event.row.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L28">boxrec-pages/profile/boxrec.page.profile.event.row.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecprofileeventlinks.html" class="tsd-signature-type">BoxrecProfileEventLinks</a></h4>
@@ -204,7 +204,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L36">boxrec-pages/profile/boxrec.page.profile.event.row.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L36">boxrec-pages/profile/boxrec.page.profile.event.row.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>
@@ -221,7 +221,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L40">boxrec-pages/profile/boxrec.page.profile.event.row.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L40">boxrec-pages/profile/boxrec.page.profile.event.row.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#venue">venue</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L13">boxrec-pages/location/event/boxrec.page.event.common.row.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L13">boxrec-pages/location/event/boxrec.page.event.common.row.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -263,7 +263,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#getcolumndata">getColumnData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L31">boxrec-pages/location/event/boxrec.page.event.common.row.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L31">boxrec-pages/location/event/boxrec.page.event.common.row.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -290,7 +290,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#getvenuecolumndata">getVenueColumnData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L14">boxrec-pages/profile/boxrec.page.profile.event.row.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.event.row.ts#L14">boxrec-pages/profile/boxrec.page.profile.event.row.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>
@@ -308,7 +308,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageeventcommonrow.html">BoxrecPageEventCommonRow</a>.<a href="boxrecpageeventcommonrow.html#hasmorecolumns">hasMoreColumns</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L44">boxrec-pages/location/event/boxrec.page.event.common.row.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.page.event.common.row.ts#L44">boxrec-pages/location/event/boxrec.page.event.common.row.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/boxrecpageprofileevents.html
+++ b/docs/classes/boxrecpageprofileevents.html
@@ -144,7 +144,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L11">boxrec-pages/profile/boxrec.page.profile.events.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L11">boxrec-pages/profile/boxrec.page.profile.events.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -167,7 +167,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L11">boxrec-pages/profile/boxrec.page.profile.events.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L11">boxrec-pages/profile/boxrec.page.profile.events.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthname">birthName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -211,7 +211,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthplace">birthPlace</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L23">boxrec-pages/profile/boxrec.page.profile.events.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L23">boxrec-pages/profile/boxrec.page.profile.events.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -257,7 +257,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#globalid">globalId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -283,7 +283,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#metadata">metadata</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#name">name</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -332,7 +332,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#otherinfo">otherInfo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -354,7 +354,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L30">boxrec-pages/profile/boxrec.page.profile.events.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L30">boxrec-pages/profile/boxrec.page.profile.events.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecprofileeventsoutput.html" class="tsd-signature-type">BoxrecProfileEventsOutput</a></h4>
@@ -372,7 +372,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#picture">picture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -390,7 +390,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#residence">residence</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -413,7 +413,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#role">role</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#status">status</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -471,7 +471,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpageprofilemanager.html
+++ b/docs/classes/boxrecpageprofilemanager.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.ts#L8">boxrec-pages/profile/boxrec.page.profile.manager.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.ts#L8">boxrec-pages/profile/boxrec.page.profile.manager.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -165,7 +165,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.ts#L8">boxrec-pages/profile/boxrec.page.profile.manager.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.ts#L8">boxrec-pages/profile/boxrec.page.profile.manager.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthname">birthName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthplace">birthPlace</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.ts#L20">boxrec-pages/profile/boxrec.page.profile.manager.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.ts#L20">boxrec-pages/profile/boxrec.page.profile.manager.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpageprofilemanagerboxerrow.html" class="tsd-signature-type">BoxrecPageProfileManagerBoxerRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -249,7 +249,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#globalid">globalId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#metadata">metadata</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#name">name</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -324,7 +324,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#otherinfo">otherInfo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -346,7 +346,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.ts#L27">boxrec-pages/profile/boxrec.page.profile.manager.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.ts#L27">boxrec-pages/profile/boxrec.page.profile.manager.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecprofilemanageroutput.html" class="tsd-signature-type">BoxrecProfileManagerOutput</a></h4>
@@ -364,7 +364,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#picture">picture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -382,7 +382,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#residence">residence</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -405,7 +405,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#role">role</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -429,7 +429,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#status">status</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -463,7 +463,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpageprofilemanagerboxerrow.html
+++ b/docs/classes/boxrecpageprofilemanagerboxerrow.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L10">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L10">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L17">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L17">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L26">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L26">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -176,7 +176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L35">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L35">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a>
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L39">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L39">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -213,7 +213,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L43">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L43">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L47">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L47">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -250,7 +250,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L51">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L51">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L55">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts#L55">boxrec-pages/profile/boxrec.page.profile.manager.boxer.row.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../globals.html#stance" class="tsd-signature-type">Stance</a>

--- a/docs/classes/boxrecpageprofileothercommon.html
+++ b/docs/classes/boxrecpageprofileothercommon.html
@@ -141,7 +141,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.ts#L13">boxrec-pages/profile/boxrec.page.profile.other.common.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.ts#L13">boxrec-pages/profile/boxrec.page.profile.other.common.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -164,7 +164,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.ts#L13">boxrec-pages/profile/boxrec.page.profile.other.common.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.ts#L13">boxrec-pages/profile/boxrec.page.profile.other.common.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthname">birthName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthplace">birthPlace</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -230,7 +230,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.ts#L26">boxrec-pages/profile/boxrec.page.profile.other.common.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.ts#L26">boxrec-pages/profile/boxrec.page.profile.other.common.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -255,7 +255,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#globalid">globalId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -281,7 +281,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#metadata">metadata</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -307,7 +307,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#name">name</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -330,7 +330,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#otherinfo">otherInfo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -352,7 +352,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.ts#L31">boxrec-pages/profile/boxrec.page.profile.other.common.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.ts#L31">boxrec-pages/profile/boxrec.page.profile.other.common.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecprofileotheroutput.html" class="tsd-signature-type">BoxrecProfileOtherOutput</a></h4>
@@ -370,7 +370,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#picture">picture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -388,7 +388,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#residence">residence</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -411,7 +411,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#role">role</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -435,7 +435,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#status">status</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -469,7 +469,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpageprofileothercommonboutrow.html
+++ b/docs/classes/boxrecpageprofileothercommonboutrow.html
@@ -135,7 +135,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecprofilecommonrow.html">BoxrecProfileCommonRow</a>.<a href="boxrecprofilecommonrow.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L8">boxrec-pages/profile/boxrec.profile.common.row.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L8">boxrec-pages/profile/boxrec.profile.common.row.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecprofilecommonrow.html">BoxrecProfileCommonRow</a>.<a href="boxrecprofilecommonrow.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L9">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L9">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L15">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L15">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -195,7 +195,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L19">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L19">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -212,7 +212,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L27">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L27">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -232,7 +232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L32">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L32">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -250,7 +250,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecprofilecommonrow.html">BoxrecProfileCommonRow</a>.<a href="boxrecprofilecommonrow.html#links">links</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L15">boxrec-pages/profile/boxrec.profile.common.row.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L15">boxrec-pages/profile/boxrec.profile.common.row.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecgenerallinks.html" class="tsd-signature-type">BoxrecGeneralLinks</a></h4>
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L36">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L36">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L40">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L40">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -304,7 +304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L44">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L44">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L48">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L48">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a></h4>
@@ -338,7 +338,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L52">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L52">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -358,7 +358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L56">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L56">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L60">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L60">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:60</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -392,7 +392,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L64">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L64">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:64</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -409,7 +409,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L72">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L72">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -426,7 +426,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L76">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L76">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -450,7 +450,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecprofilecommonrow.html">BoxrecProfileCommonRow</a>.<a href="boxrecprofilecommonrow.html#parselinks">parseLinks</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L11">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts#L11">boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>

--- a/docs/classes/boxrecpageprofilepromoter.html
+++ b/docs/classes/boxrecpageprofilepromoter.html
@@ -134,7 +134,7 @@
 								<p>Inherited from <a href="boxrecpageprofileevents.html">BoxrecPageProfileEvents</a>.<a href="boxrecpageprofileevents.html#constructor">constructor</a></p>
 								<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L11">boxrec-pages/profile/boxrec.page.profile.events.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L11">boxrec-pages/profile/boxrec.page.profile.events.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -158,7 +158,7 @@
 						<p>Inherited from <a href="boxrecpageprofileevents.html">BoxrecPageProfileEvents</a>.<a href="boxrecpageprofileevents.html#_">$</a></p>
 						<p>Overrides <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L11">boxrec-pages/profile/boxrec.page.profile.events.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L11">boxrec-pages/profile/boxrec.page.profile.events.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthname">birthName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L22">boxrec-pages/profile/boxrec.page.profile.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#birthplace">birthPlace</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L36">boxrec-pages/profile/boxrec.page.profile.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.promoter.ts#L8">boxrec-pages/profile/boxrec.page.profile.promoter.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.promoter.ts#L8">boxrec-pages/profile/boxrec.page.profile.promoter.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -245,7 +245,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofileevents.html">BoxrecPageProfileEvents</a>.<a href="boxrecpageprofileevents.html#events">events</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L23">boxrec-pages/profile/boxrec.page.profile.events.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.events.ts#L23">boxrec-pages/profile/boxrec.page.profile.events.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -269,7 +269,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#globalid">globalId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L46">boxrec-pages/profile/boxrec.page.profile.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#metadata">metadata</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L64">boxrec-pages/profile/boxrec.page.profile.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#name">name</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L77">boxrec-pages/profile/boxrec.page.profile.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#otherinfo">otherInfo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L85">boxrec-pages/profile/boxrec.page.profile.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -367,7 +367,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageprofileevents.html">BoxrecPageProfileEvents</a>.<a href="boxrecpageprofileevents.html#output">output</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.promoter.ts#L18">boxrec-pages/profile/boxrec.page.profile.promoter.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.promoter.ts#L18">boxrec-pages/profile/boxrec.page.profile.promoter.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecprofilepromoteroutput.html" class="tsd-signature-type">BoxrecProfilePromoterOutput</a></h4>
@@ -385,7 +385,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#picture">picture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L89">boxrec-pages/profile/boxrec.page.profile.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -403,7 +403,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#residence">residence</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L97">boxrec-pages/profile/boxrec.page.profile.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -426,7 +426,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#role">role</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L108">boxrec-pages/profile/boxrec.page.profile.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -450,7 +450,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageprofile.html">BoxrecPageProfile</a>.<a href="boxrecpageprofile.html#status">status</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.ts#L163">boxrec-pages/profile/boxrec.page.profile.ts:163</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -484,7 +484,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpageratings.html
+++ b/docs/classes/boxrecpageratings.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.ts#L12">boxrec-pages/ratings/boxrec.page.ratings.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.ts#L12">boxrec-pages/ratings/boxrec.page.ratings.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.ts#L12">boxrec-pages/ratings/boxrec.page.ratings.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.ts#L12">boxrec-pages/ratings/boxrec.page.ratings.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.ts#L19">boxrec-pages/ratings/boxrec.page.ratings.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.ts#L19">boxrec-pages/ratings/boxrec.page.ratings.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpageratingsrow.html" class="tsd-signature-type">BoxrecPageRatingsRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -190,7 +190,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#numberofpages">numberOfPages</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L12">boxrec-common-tables/boxrec-page-lists.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L12">boxrec-common-tables/boxrec-page-lists.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.ts#L23">boxrec-pages/ratings/boxrec.page.ratings.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.ts#L23">boxrec-pages/ratings/boxrec.page.ratings.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecratingsoutput.html" class="tsd-signature-type">BoxrecRatingsOutput</a></h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#getnumberofpages">getNumberOfPages</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L16">boxrec-common-tables/boxrec-page-lists.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L16">boxrec-common-tables/boxrec-page-lists.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpagelists.html">BoxrecPageLists</a>.<a href="boxrecpagelists.html#gettabledata">getTableData</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-page-lists.ts#L21">boxrec-common-tables/boxrec-page-lists.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-page-lists.ts#L21">boxrec-common-tables/boxrec-page-lists.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/boxrecpageratingsrow.html
+++ b/docs/classes/boxrecpageratingsrow.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L9">boxrec-pages/ratings/boxrec.page.ratings.row.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L9">boxrec-pages/ratings/boxrec.page.ratings.row.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L16">boxrec-pages/ratings/boxrec.page.ratings.row.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L16">boxrec-pages/ratings/boxrec.page.ratings.row.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L25">boxrec-pages/ratings/boxrec.page.ratings.row.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L25">boxrec-pages/ratings/boxrec.page.ratings.row.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a>
@@ -183,7 +183,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L29">boxrec-pages/ratings/boxrec.page.ratings.row.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L29">boxrec-pages/ratings/boxrec.page.ratings.row.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span>
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L41">boxrec-pages/ratings/boxrec.page.ratings.row.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L41">boxrec-pages/ratings/boxrec.page.ratings.row.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -220,7 +220,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L45">boxrec-pages/ratings/boxrec.page.ratings.row.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L45">boxrec-pages/ratings/boxrec.page.ratings.row.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -237,7 +237,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L49">boxrec-pages/ratings/boxrec.page.ratings.row.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L49">boxrec-pages/ratings/boxrec.page.ratings.row.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L53">boxrec-pages/ratings/boxrec.page.ratings.row.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L53">boxrec-pages/ratings/boxrec.page.ratings.row.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -274,7 +274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L63">boxrec-pages/ratings/boxrec.page.ratings.row.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L63">boxrec-pages/ratings/boxrec.page.ratings.row.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -294,7 +294,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L72">boxrec-pages/ratings/boxrec.page.ratings.row.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L72">boxrec-pages/ratings/boxrec.page.ratings.row.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -314,7 +314,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L76">boxrec-pages/ratings/boxrec.page.ratings.row.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L76">boxrec-pages/ratings/boxrec.page.ratings.row.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -331,7 +331,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L80">boxrec-pages/ratings/boxrec.page.ratings.row.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L80">boxrec-pages/ratings/boxrec.page.ratings.row.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>
@@ -348,7 +348,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L84">boxrec-pages/ratings/boxrec.page.ratings.row.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.page.ratings.row.ts#L84">boxrec-pages/ratings/boxrec.page.ratings.row.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../globals.html#stance" class="tsd-signature-type">Stance</a>

--- a/docs/classes/boxrecpageschedule.html
+++ b/docs/classes/boxrecpageschedule.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecpageschedulecommon.html">BoxrecPageScheduleCommon</a>.<a href="boxrecpageschedulecommon.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L14">boxrec-pages/schedule/boxrec.page.schedule.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L14">boxrec-pages/schedule/boxrec.page.schedule.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecpageschedulecommon.html">BoxrecPageScheduleCommon</a>.<a href="boxrecpageschedulecommon.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L14">boxrec-pages/schedule/boxrec.page.schedule.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L14">boxrec-pages/schedule/boxrec.page.schedule.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L21">boxrec-pages/schedule/boxrec.page.schedule.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L21">boxrec-pages/schedule/boxrec.page.schedule.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpageevent.html" class="tsd-signature-type">BoxrecPageEvent</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L25">boxrec-pages/schedule/boxrec.page.schedule.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L25">boxrec-pages/schedule/boxrec.page.schedule.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -206,7 +206,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L30">boxrec-pages/schedule/boxrec.page.schedule.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.ts#L30">boxrec-pages/schedule/boxrec.page.schedule.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecscheduleoutput.html" class="tsd-signature-type">BoxrecScheduleOutput</a></h4>
@@ -227,7 +227,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecpageschedulecommon.html">BoxrecPageScheduleCommon</a>.<a href="boxrecpageschedulecommon.html#parse">parse</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L12">boxrec-pages/schedule/boxrec.page.schedule.common.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L12">boxrec-pages/schedule/boxrec.page.schedule.common.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>

--- a/docs/classes/boxrecpageschedulecommon.html
+++ b/docs/classes/boxrecpageschedulecommon.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L6">boxrec-pages/schedule/boxrec.page.schedule.common.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L6">boxrec-pages/schedule/boxrec.page.schedule.common.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">$<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CheerioStatic</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L6">boxrec-pages/schedule/boxrec.page.schedule.common.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L6">boxrec-pages/schedule/boxrec.page.schedule.common.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L12">boxrec-pages/schedule/boxrec.page.schedule.common.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.common.ts#L12">boxrec-pages/schedule/boxrec.page.schedule.common.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>

--- a/docs/classes/boxrecpagesearch.html
+++ b/docs/classes/boxrecpagesearch.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.ts#L12">boxrec-pages/search/boxrec.page.search.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.ts#L12">boxrec-pages/search/boxrec.page.search.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.ts#L18">boxrec-pages/search/boxrec.page.search.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.ts#L18">boxrec-pages/search/boxrec.page.search.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecsearchoutput.html" class="tsd-signature-type">BoxrecSearchOutput</a></h4>
@@ -155,7 +155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.ts#L24">boxrec-pages/search/boxrec.page.search.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.ts#L24">boxrec-pages/search/boxrec.page.search.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecsearch.html" class="tsd-signature-type">BoxrecSearch</a><span class="tsd-signature-symbol">[]</span></h4>

--- a/docs/classes/boxrecpagesearchrow.html
+++ b/docs/classes/boxrecpagesearchrow.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L9">boxrec-pages/search/boxrec.page.search.row.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L9">boxrec-pages/search/boxrec.page.search.row.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L16">boxrec-pages/search/boxrec.page.search.row.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L16">boxrec-pages/search/boxrec.page.search.row.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L20">boxrec-pages/search/boxrec.page.search.row.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L20">boxrec-pages/search/boxrec.page.search.row.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L24">boxrec-pages/search/boxrec.page.search.row.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L24">boxrec-pages/search/boxrec.page.search.row.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a>
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L28">boxrec-pages/search/boxrec.page.search.row.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L28">boxrec-pages/search/boxrec.page.search.row.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L32">boxrec-pages/search/boxrec.page.search.row.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L32">boxrec-pages/search/boxrec.page.search.row.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -227,7 +227,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L36">boxrec-pages/search/boxrec.page.search.row.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L36">boxrec-pages/search/boxrec.page.search.row.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -247,7 +247,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L40">boxrec-pages/search/boxrec.page.search.row.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L40">boxrec-pages/search/boxrec.page.search.row.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.row.ts#L44">boxrec-pages/search/boxrec.page.search.row.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.row.ts#L44">boxrec-pages/search/boxrec.page.search.row.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>

--- a/docs/classes/boxrecpagetitle.html
+++ b/docs/classes/boxrecpagetitle.html
@@ -146,7 +146,7 @@
                 <aside class="tsd-sources">
         <p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#constructor">constructor</a></p>
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.ts#L22">boxrec-pages/title/boxrec.page.title.ts:22</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.ts#L22">boxrec-pages/title/boxrec.page.title.ts:22</a></li>
         </ul>
 </aside>
 
@@ -179,7 +179,7 @@
 <aside class="tsd-sources">
         <p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#_">$</a></p>
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.ts#L14">boxrec-pages/title/boxrec.page.title.ts:14</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.ts#L14">boxrec-pages/title/boxrec.page.title.ts:14</a></li>
         </ul>
 </aside>
 
@@ -202,7 +202,7 @@
             <li class="tsd-description">
                     <aside class="tsd-sources">
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.ts#L33">boxrec-pages/title/boxrec.page.title.ts:33</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.ts#L33">boxrec-pages/title/boxrec.page.title.ts:33</a></li>
         </ul>
 </aside>
         <div class="tsd-comment tsd-typography">
@@ -235,7 +235,7 @@
             <li class="tsd-description">
                     <aside class="tsd-sources">
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.ts#L41">boxrec-pages/title/boxrec.page.title.ts:41</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.ts#L41">boxrec-pages/title/boxrec.page.title.ts:41</a></li>
         </ul>
 </aside>
         <div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
             <li class="tsd-description">
                     <aside class="tsd-sources">
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.ts#L64">boxrec-pages/title/boxrec.page.title.ts:64</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.ts#L64">boxrec-pages/title/boxrec.page.title.ts:64</a></li>
         </ul>
 </aside>
 
@@ -295,7 +295,7 @@
                     <aside class="tsd-sources">
         <p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#numberofbouts">numberOfBouts</a></p>
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.ts#L20">boxrec-pages/title/boxrec.page.title.ts:20</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.ts#L20">boxrec-pages/title/boxrec.page.title.ts:20</a></li>
         </ul>
 </aside>
         <div class="tsd-comment tsd-typography">
@@ -328,7 +328,7 @@
             <li class="tsd-description">
                     <aside class="tsd-sources">
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.ts#L68">boxrec-pages/title/boxrec.page.title.ts:68</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.ts#L68">boxrec-pages/title/boxrec.page.title.ts:68</a></li>
         </ul>
 </aside>
 
@@ -357,7 +357,7 @@
                 <aside class="tsd-sources">
         <p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#parsebouts">parseBouts</a></p>
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
         </ul>
 </aside>
 
@@ -383,7 +383,7 @@
                 <aside class="tsd-sources">
         <p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
         <ul>
-                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+                    <li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
         </ul>
 </aside>
 

--- a/docs/classes/boxrecpagetitlerow.html
+++ b/docs/classes/boxrecpagetitlerow.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L10">boxrec-pages/title/boxrec.page.title.row.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L10">boxrec-pages/title/boxrec.page.title.row.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L17">boxrec-pages/title/boxrec.page.title.row.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L17">boxrec-pages/title/boxrec.page.title.row.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -159,7 +159,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L21">boxrec-pages/title/boxrec.page.title.row.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L21">boxrec-pages/title/boxrec.page.title.row.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -176,7 +176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L25">boxrec-pages/title/boxrec.page.title.row.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L25">boxrec-pages/title/boxrec.page.title.row.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L29">boxrec-pages/title/boxrec.page.title.row.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L29">boxrec-pages/title/boxrec.page.title.row.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecgenerallinks.html" class="tsd-signature-type">BoxrecGeneralLinks</a></h4>
@@ -213,7 +213,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L38">boxrec-pages/title/boxrec.page.title.row.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L38">boxrec-pages/title/boxrec.page.title.row.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>
@@ -230,7 +230,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L42">boxrec-pages/title/boxrec.page.title.row.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L42">boxrec-pages/title/boxrec.page.title.row.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -250,7 +250,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L46">boxrec-pages/title/boxrec.page.title.row.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L46">boxrec-pages/title/boxrec.page.title.row.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L58">boxrec-pages/title/boxrec.page.title.row.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L58">boxrec-pages/title/boxrec.page.title.row.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a></h4>
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L62">boxrec-pages/title/boxrec.page.title.row.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L62">boxrec-pages/title/boxrec.page.title.row.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -304,7 +304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L66">boxrec-pages/title/boxrec.page.title.row.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L66">boxrec-pages/title/boxrec.page.title.row.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.row.ts#L70">boxrec-pages/title/boxrec.page.title.row.ts:70</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.row.ts#L70">boxrec-pages/title/boxrec.page.title.row.ts:70</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>

--- a/docs/classes/boxrecpagetitles.html
+++ b/docs/classes/boxrecpagetitles.html
@@ -133,7 +133,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.ts#L13">boxrec-pages/titles/boxrec.page.titles.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.ts#L13">boxrec-pages/titles/boxrec.page.titles.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.ts#L13">boxrec-pages/titles/boxrec.page.titles.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.ts#L13">boxrec-pages/titles/boxrec.page.titles.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.ts#L20">boxrec-pages/titles/boxrec.page.titles.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.ts#L20">boxrec-pages/titles/boxrec.page.titles.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpagetitlesrow.html" class="tsd-signature-type">BoxrecPageTitlesRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#numberofbouts">numberOfBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.ts#L24">boxrec-pages/titles/boxrec.page.titles.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.ts#L24">boxrec-pages/titles/boxrec.page.titles.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.ts#L29">boxrec-pages/titles/boxrec.page.titles.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.ts#L29">boxrec-pages/titles/boxrec.page.titles.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrectitlesoutput.html" class="tsd-signature-type">BoxrecTitlesOutput</a></h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparsebouts.html">BoxrecParseBouts</a>.<a href="boxrecparsebouts.html#parsebouts">parseBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -264,7 +264,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecpagetitlesrow.html
+++ b/docs/classes/boxrecpagetitlesrow.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrectitlescommon.html">BoxrecTitlesCommon</a>.<a href="boxrectitlescommon.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L15">boxrec-pages/titles/boxrec.page.titles.row.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L15">boxrec-pages/titles/boxrec.page.titles.row.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrectitlescommon.html">BoxrecTitlesCommon</a>.<a href="boxrectitlescommon.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L10">boxrec-pages/titles/boxrec.page.titles.row.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L10">boxrec-pages/titles/boxrec.page.titles.row.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L23">boxrec-pages/titles/boxrec.page.titles.row.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L23">boxrec-pages/titles/boxrec.page.titles.row.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -192,7 +192,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L27">boxrec-pages/titles/boxrec.page.titles.row.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L27">boxrec-pages/titles/boxrec.page.titles.row.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a>
@@ -212,7 +212,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L31">boxrec-pages/titles/boxrec.page.titles.row.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L31">boxrec-pages/titles/boxrec.page.titles.row.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -229,7 +229,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L35">boxrec-pages/titles/boxrec.page.titles.row.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L35">boxrec-pages/titles/boxrec.page.titles.row.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -250,7 +250,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrectitlescommon.html">BoxrecTitlesCommon</a>.<a href="boxrectitlescommon.html#links">links</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.titles.common.ts#L13">boxrec-pages/titles/boxrec.titles.common.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.titles.common.ts#L13">boxrec-pages/titles/boxrec.titles.common.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecgenerallinks.html" class="tsd-signature-type">BoxrecGeneralLinks</a></h4>
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L39">boxrec-pages/titles/boxrec.page.titles.row.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L39">boxrec-pages/titles/boxrec.page.titles.row.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L44">boxrec-pages/titles/boxrec.page.titles.row.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L44">boxrec-pages/titles/boxrec.page.titles.row.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -304,7 +304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L48">boxrec-pages/titles/boxrec.page.titles.row.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L48">boxrec-pages/titles/boxrec.page.titles.row.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L61">boxrec-pages/titles/boxrec.page.titles.row.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L61">boxrec-pages/titles/boxrec.page.titles.row.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a></h4>
@@ -338,7 +338,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L65">boxrec-pages/titles/boxrec.page.titles.row.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L65">boxrec-pages/titles/boxrec.page.titles.row.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -358,7 +358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L70">boxrec-pages/titles/boxrec.page.titles.row.ts:70</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L70">boxrec-pages/titles/boxrec.page.titles.row.ts:70</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></h4>
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L75">boxrec-pages/titles/boxrec.page.titles.row.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L75">boxrec-pages/titles/boxrec.page.titles.row.ts:75</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -399,7 +399,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrectitlescommon.html">BoxrecTitlesCommon</a>.<a href="boxrectitlescommon.html#parselinks">parseLinks</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L12">boxrec-pages/titles/boxrec.page.titles.row.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.titles.row.ts#L12">boxrec-pages/titles/boxrec.page.titles.row.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>

--- a/docs/classes/boxrecpagevenue.html
+++ b/docs/classes/boxrecpagevenue.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.ts#L13">boxrec-pages/venue/boxrec.page.venue.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.ts#L13">boxrec-pages/venue/boxrec.page.venue.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.ts#L23">boxrec-pages/venue/boxrec.page.venue.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.ts#L23">boxrec-pages/venue/boxrec.page.venue.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -165,7 +165,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.ts#L34">boxrec-pages/venue/boxrec.page.venue.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.ts#L34">boxrec-pages/venue/boxrec.page.venue.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -188,7 +188,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.ts#L45">boxrec-pages/venue/boxrec.page.venue.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.ts#L45">boxrec-pages/venue/boxrec.page.venue.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.ts#L50">boxrec-pages/venue/boxrec.page.venue.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.ts#L50">boxrec-pages/venue/boxrec.page.venue.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>
@@ -228,7 +228,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.ts#L54">boxrec-pages/venue/boxrec.page.venue.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.ts#L54">boxrec-pages/venue/boxrec.page.venue.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -245,7 +245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.ts#L58">boxrec-pages/venue/boxrec.page.venue.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.ts#L58">boxrec-pages/venue/boxrec.page.venue.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecvenueoutput.html" class="tsd-signature-type">BoxrecVenueOutput</a></h4>

--- a/docs/classes/boxrecpagevenueeventsrow.html
+++ b/docs/classes/boxrecpagevenueeventsrow.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L8">boxrec-pages/venue/boxrec.page.venue.events.row.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L8">boxrec-pages/venue/boxrec.page.venue.events.row.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L15">boxrec-pages/venue/boxrec.page.venue.events.row.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L15">boxrec-pages/venue/boxrec.page.venue.events.row.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L19">boxrec-pages/venue/boxrec.page.venue.events.row.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L19">boxrec-pages/venue/boxrec.page.venue.events.row.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L23">boxrec-pages/venue/boxrec.page.venue.events.row.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L23">boxrec-pages/venue/boxrec.page.venue.events.row.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span>
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L27">boxrec-pages/venue/boxrec.page.venue.events.row.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.events.row.ts#L27">boxrec-pages/venue/boxrec.page.venue.events.row.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></h4>

--- a/docs/classes/boxrecpagewatch.html
+++ b/docs/classes/boxrecpagewatch.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.ts#L7">boxrec-pages/watch/boxrec.page.watch.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.ts#L7">boxrec-pages/watch/boxrec.page.watch.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.ts#L13">boxrec-pages/watch/boxrec.page.watch.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.ts#L13">boxrec-pages/watch/boxrec.page.watch.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="boxrecpagewatchrow.html" class="tsd-signature-type">BoxrecPageWatchRow</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.ts#L32">boxrec-pages/watch/boxrec.page.watch.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.ts#L32">boxrec-pages/watch/boxrec.page.watch.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecwatchoutput.html" class="tsd-signature-type">BoxrecWatchOutput</a></h4>
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.ts#L43">boxrec-pages/watch/boxrec.page.watch.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.ts#L43">boxrec-pages/watch/boxrec.page.watch.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/boxrecpagewatchrow.html
+++ b/docs/classes/boxrecpagewatchrow.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L9">boxrec-pages/watch/boxrec.page.watch.row.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L9">boxrec-pages/watch/boxrec.page.watch.row.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -135,7 +135,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L15">boxrec-pages/watch/boxrec.page.watch.row.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L15">boxrec-pages/watch/boxrec.page.watch.row.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>
@@ -155,7 +155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L19">boxrec-pages/watch/boxrec.page.watch.row.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L19">boxrec-pages/watch/boxrec.page.watch.row.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L23">boxrec-pages/watch/boxrec.page.watch.row.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L23">boxrec-pages/watch/boxrec.page.watch.row.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -192,7 +192,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L27">boxrec-pages/watch/boxrec.page.watch.row.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L27">boxrec-pages/watch/boxrec.page.watch.row.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L31">boxrec-pages/watch/boxrec.page.watch.row.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L31">boxrec-pages/watch/boxrec.page.watch.row.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -226,7 +226,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L36">boxrec-pages/watch/boxrec.page.watch.row.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L36">boxrec-pages/watch/boxrec.page.watch.row.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/record.html" class="tsd-signature-type">Record</a></h4>
@@ -243,7 +243,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L40">boxrec-pages/watch/boxrec.page.watch.row.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.page.watch.row.ts#L40">boxrec-pages/watch/boxrec.page.watch.row.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span>

--- a/docs/classes/boxrecparsebouts.html
+++ b/docs/classes/boxrecparsebouts.html
@@ -133,7 +133,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L6">boxrec-pages/event/boxrec.parse.bouts.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L6">boxrec-pages/event/boxrec.parse.bouts.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#_">$</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L6">boxrec-pages/event/boxrec.parse.bouts.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L6">boxrec-pages/event/boxrec.parse.bouts.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L13">boxrec-pages/event/boxrec.parse.bouts.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.ts#L18">boxrec-pages/event/boxrec.parse.bouts.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -211,7 +211,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="boxrecparseboutsparsebouts.html">BoxrecParseBoutsParseBouts</a>.<a href="boxrecparseboutsparsebouts.html#returnbouts">returnBouts</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecparseboutsparsebouts.html
+++ b/docs/classes/boxrecparseboutsparsebouts.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L5">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L5">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">$<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CheerioStatic</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L5">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L5">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts#L11">boxrec-pages/event/boxrec.parse.bouts.parseBouts.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/boxrecprofilecommonrow.html
+++ b/docs/classes/boxrecprofilecommonrow.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L8">boxrec-pages/profile/boxrec.profile.common.row.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L8">boxrec-pages/profile/boxrec.profile.common.row.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">$<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CheerioStatic</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L8">boxrec-pages/profile/boxrec.profile.common.row.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L8">boxrec-pages/profile/boxrec.profile.common.row.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L15">boxrec-pages/profile/boxrec.profile.common.row.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L15">boxrec-pages/profile/boxrec.profile.common.row.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecgenerallinks.html" class="tsd-signature-type">BoxrecGeneralLinks</a></h4>
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L24">boxrec-pages/profile/boxrec.profile.common.row.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.common.row.ts#L24">boxrec-pages/profile/boxrec.profile.common.row.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>

--- a/docs/classes/boxrectitlescommon.html
+++ b/docs/classes/boxrectitlescommon.html
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.titles.common.ts#L7">boxrec-pages/titles/boxrec.titles.common.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.titles.common.ts#L7">boxrec-pages/titles/boxrec.titles.common.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">$<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CheerioStatic</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.titles.common.ts#L7">boxrec-pages/titles/boxrec.titles.common.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.titles.common.ts#L7">boxrec-pages/titles/boxrec.titles.common.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.titles.common.ts#L13">boxrec-pages/titles/boxrec.titles.common.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.titles.common.ts#L13">boxrec-pages/titles/boxrec.titles.common.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/boxrecgenerallinks.html" class="tsd-signature-type">BoxrecGeneralLinks</a></h4>
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.titles.common.ts#L22">boxrec-pages/titles/boxrec.titles.common.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.titles.common.ts#L22">boxrec-pages/titles/boxrec.titles.common.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Cheerio</span></h4>

--- a/docs/enums/boxingboutoutcome.html
+++ b/docs/enums/boxingboutoutcome.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">DQ<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;disqualification&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L16">boxrec-pages/event/boxrec.event.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L16">boxrec-pages/event/boxrec.event.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">KO<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;knockout&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L10">boxrec-pages/event/boxrec.event.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L10">boxrec-pages/event/boxrec.event.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">MD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;majority decision&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L12">boxrec-pages/event/boxrec.event.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L12">boxrec-pages/event/boxrec.event.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">NWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;newspaper decision&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L17">boxrec-pages/event/boxrec.event.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L17">boxrec-pages/event/boxrec.event.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">RTD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;corner retirement&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L15">boxrec-pages/event/boxrec.event.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L15">boxrec-pages/event/boxrec.event.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">SD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;split decision&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L13">boxrec-pages/event/boxrec.event.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L13">boxrec-pages/event/boxrec.event.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">TD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;technical decision&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L14">boxrec-pages/event/boxrec.event.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L14">boxrec-pages/event/boxrec.event.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">TKO<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;technical knockout&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L9">boxrec-pages/event/boxrec.event.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L9">boxrec-pages/event/boxrec.event.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">UD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;unanimous decision&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L11">boxrec-pages/event/boxrec.event.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L11">boxrec-pages/event/boxrec.event.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/boxrecprofiletable.html
+++ b/docs/enums/boxrecprofiletable.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">KOs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KOs&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L41">boxrec-pages/profile/boxrec.profile.constants.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L41">boxrec-pages/profile/boxrec.profile.constants.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">alias<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;alias&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L45">boxrec-pages/profile/boxrec.profile.constants.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L45">boxrec-pages/profile/boxrec.profile.constants.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">birth<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;birth name&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L44">boxrec-pages/profile/boxrec.profile.constants.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L44">boxrec-pages/profile/boxrec.profile.constants.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">birth<wbr>Place<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;birth place&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L54">boxrec-pages/profile/boxrec.profile.constants.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L54">boxrec-pages/profile/boxrec.profile.constants.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">born<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;born&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L46">boxrec-pages/profile/boxrec.profile.constants.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L46">boxrec-pages/profile/boxrec.profile.constants.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">bouts<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;bouts&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L39">boxrec-pages/profile/boxrec.profile.constants.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L39">boxrec-pages/profile/boxrec.profile.constants.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">company<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;company&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L55">boxrec-pages/profile/boxrec.profile.constants.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L55">boxrec-pages/profile/boxrec.profile.constants.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">debut<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;debut&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L48">boxrec-pages/profile/boxrec.profile.constants.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L48">boxrec-pages/profile/boxrec.profile.constants.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;division&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L49">boxrec-pages/profile/boxrec.profile.constants.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L49">boxrec-pages/profile/boxrec.profile.constants.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;global ID&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L34">boxrec-pages/profile/boxrec.profile.constants.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L34">boxrec-pages/profile/boxrec.profile.constants.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;height&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L51">boxrec-pages/profile/boxrec.profile.constants.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L51">boxrec-pages/profile/boxrec.profile.constants.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 					<div class="tsd-signature tsd-kind-icon">nationality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;nationality&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L47">boxrec-pages/profile/boxrec.profile.constants.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L47">boxrec-pages/profile/boxrec.profile.constants.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">ranking<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ranking&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L37">boxrec-pages/profile/boxrec.profile.constants.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L37">boxrec-pages/profile/boxrec.profile.constants.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -237,7 +237,7 @@
 					<div class="tsd-signature tsd-kind-icon">rating<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;rating&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L36">boxrec-pages/profile/boxrec.profile.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L36">boxrec-pages/profile/boxrec.profile.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">reach<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;reach&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L52">boxrec-pages/profile/boxrec.profile.constants.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L52">boxrec-pages/profile/boxrec.profile.constants.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">registered<wbr>Contact<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;registered contact&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L56">boxrec-pages/profile/boxrec.profile.constants.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L56">boxrec-pages/profile/boxrec.profile.constants.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -267,7 +267,7 @@
 					<div class="tsd-signature tsd-kind-icon">residence<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;residence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L53">boxrec-pages/profile/boxrec.profile.constants.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L53">boxrec-pages/profile/boxrec.profile.constants.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -277,7 +277,7 @@
 					<div class="tsd-signature tsd-kind-icon">role<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;role&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L35">boxrec-pages/profile/boxrec.profile.constants.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L35">boxrec-pages/profile/boxrec.profile.constants.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -287,7 +287,7 @@
 					<div class="tsd-signature tsd-kind-icon">rounds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;rounds&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L40">boxrec-pages/profile/boxrec.profile.constants.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L40">boxrec-pages/profile/boxrec.profile.constants.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@
 					<div class="tsd-signature tsd-kind-icon">stance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;stance&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L50">boxrec-pages/profile/boxrec.profile.constants.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L50">boxrec-pages/profile/boxrec.profile.constants.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -307,7 +307,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;status&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L42">boxrec-pages/profile/boxrec.profile.constants.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L42">boxrec-pages/profile/boxrec.profile.constants.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -317,7 +317,7 @@
 					<div class="tsd-signature tsd-kind-icon">titles<wbr>Held<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;titles held&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L43">boxrec-pages/profile/boxrec.profile.constants.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L43">boxrec-pages/profile/boxrec.profile.constants.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -327,7 +327,7 @@
 					<div class="tsd-signature tsd-kind-icon">vadacbp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;VADA CBP&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L38">boxrec-pages/profile/boxrec.profile.constants.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L38">boxrec-pages/profile/boxrec.profile.constants.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/boxrecrole.html
+++ b/docs/enums/boxrecrole.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">all<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;all&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L16">boxrec-pages/search/boxrec.search.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L16">boxrec-pages/search/boxrec.search.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">boxer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;boxer&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L17">boxrec-pages/search/boxrec.search.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L17">boxrec-pages/search/boxrec.search.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">doctor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;doctor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L18">boxrec-pages/search/boxrec.search.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L18">boxrec-pages/search/boxrec.search.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">inspector<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;inspector&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L19">boxrec-pages/search/boxrec.search.constants.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L19">boxrec-pages/search/boxrec.search.constants.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">judge<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;judge&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L20">boxrec-pages/search/boxrec.search.constants.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L20">boxrec-pages/search/boxrec.search.constants.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">manager<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;manager&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L21">boxrec-pages/search/boxrec.search.constants.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L21">boxrec-pages/search/boxrec.search.constants.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">matchmaker<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;matchmaker&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L22">boxrec-pages/search/boxrec.search.constants.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L22">boxrec-pages/search/boxrec.search.constants.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">promoter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;promoter&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L23">boxrec-pages/search/boxrec.search.constants.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L23">boxrec-pages/search/boxrec.search.constants.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">referee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;referee&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L24">boxrec-pages/search/boxrec.search.constants.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L24">boxrec-pages/search/boxrec.search.constants.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">supervisor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;supervisor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L25">boxrec-pages/search/boxrec.search.constants.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L25">boxrec-pages/search/boxrec.search.constants.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/boxrecstatus.html
+++ b/docs/enums/boxrecstatus.html
@@ -86,7 +86,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;a&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L4">boxrec-pages/search/boxrec.search.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L4">boxrec-pages/search/boxrec.search.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">all<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L5">boxrec-pages/search/boxrec.search.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L5">boxrec-pages/search/boxrec.search.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/country.html
+++ b/docs/enums/country.html
@@ -330,7 +330,7 @@
 					<div class="tsd-signature tsd-kind-icon">Afghanistan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AF&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L28">boxrec-pages/location/people/boxrec.location.people.constants.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L28">boxrec-pages/location/people/boxrec.location.people.constants.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -340,7 +340,7 @@
 					<div class="tsd-signature tsd-kind-icon">Albania<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L29">boxrec-pages/location/people/boxrec.location.people.constants.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L29">boxrec-pages/location/people/boxrec.location.people.constants.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -350,7 +350,7 @@
 					<div class="tsd-signature tsd-kind-icon">Algeria<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;DZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L30">boxrec-pages/location/people/boxrec.location.people.constants.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L30">boxrec-pages/location/people/boxrec.location.people.constants.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -360,7 +360,7 @@
 					<div class="tsd-signature tsd-kind-icon">American <wbr>Samoa<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L31">boxrec-pages/location/people/boxrec.location.people.constants.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L31">boxrec-pages/location/people/boxrec.location.people.constants.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -370,7 +370,7 @@
 					<div class="tsd-signature tsd-kind-icon">Andorra<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AD&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L32">boxrec-pages/location/people/boxrec.location.people.constants.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L32">boxrec-pages/location/people/boxrec.location.people.constants.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -380,7 +380,7 @@
 					<div class="tsd-signature tsd-kind-icon">Angola<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L33">boxrec-pages/location/people/boxrec.location.people.constants.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L33">boxrec-pages/location/people/boxrec.location.people.constants.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -390,7 +390,7 @@
 					<div class="tsd-signature tsd-kind-icon">Anguilla<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L34">boxrec-pages/location/people/boxrec.location.people.constants.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L34">boxrec-pages/location/people/boxrec.location.people.constants.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -400,7 +400,7 @@
 					<div class="tsd-signature tsd-kind-icon">Antarctica<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AQ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L35">boxrec-pages/location/people/boxrec.location.people.constants.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L35">boxrec-pages/location/people/boxrec.location.people.constants.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -410,7 +410,7 @@
 					<div class="tsd-signature tsd-kind-icon">Antigua <wbr>And <wbr>Barbuda<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L36">boxrec-pages/location/people/boxrec.location.people.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L36">boxrec-pages/location/people/boxrec.location.people.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -420,7 +420,7 @@
 					<div class="tsd-signature tsd-kind-icon">Argentina<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L37">boxrec-pages/location/people/boxrec.location.people.constants.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L37">boxrec-pages/location/people/boxrec.location.people.constants.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -430,7 +430,7 @@
 					<div class="tsd-signature tsd-kind-icon">Armenia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L38">boxrec-pages/location/people/boxrec.location.people.constants.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L38">boxrec-pages/location/people/boxrec.location.people.constants.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -440,7 +440,7 @@
 					<div class="tsd-signature tsd-kind-icon">Aruba<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L39">boxrec-pages/location/people/boxrec.location.people.constants.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L39">boxrec-pages/location/people/boxrec.location.people.constants.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -450,7 +450,7 @@
 					<div class="tsd-signature tsd-kind-icon">Australia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L40">boxrec-pages/location/people/boxrec.location.people.constants.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L40">boxrec-pages/location/people/boxrec.location.people.constants.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -460,7 +460,7 @@
 					<div class="tsd-signature tsd-kind-icon">Austria<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L41">boxrec-pages/location/people/boxrec.location.people.constants.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L41">boxrec-pages/location/people/boxrec.location.people.constants.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -470,7 +470,7 @@
 					<div class="tsd-signature tsd-kind-icon">Azerbaijan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L42">boxrec-pages/location/people/boxrec.location.people.constants.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L42">boxrec-pages/location/people/boxrec.location.people.constants.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -480,7 +480,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bahamas<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L43">boxrec-pages/location/people/boxrec.location.people.constants.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L43">boxrec-pages/location/people/boxrec.location.people.constants.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -490,7 +490,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bahrain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L44">boxrec-pages/location/people/boxrec.location.people.constants.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L44">boxrec-pages/location/people/boxrec.location.people.constants.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -500,7 +500,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bangladesh<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BD&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L45">boxrec-pages/location/people/boxrec.location.people.constants.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L45">boxrec-pages/location/people/boxrec.location.people.constants.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -510,7 +510,7 @@
 					<div class="tsd-signature tsd-kind-icon">Barbados<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BB&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L46">boxrec-pages/location/people/boxrec.location.people.constants.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L46">boxrec-pages/location/people/boxrec.location.people.constants.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -520,7 +520,7 @@
 					<div class="tsd-signature tsd-kind-icon">Belarus<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L47">boxrec-pages/location/people/boxrec.location.people.constants.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L47">boxrec-pages/location/people/boxrec.location.people.constants.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -530,7 +530,7 @@
 					<div class="tsd-signature tsd-kind-icon">Belgium<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L48">boxrec-pages/location/people/boxrec.location.people.constants.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L48">boxrec-pages/location/people/boxrec.location.people.constants.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -540,7 +540,7 @@
 					<div class="tsd-signature tsd-kind-icon">Belize<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L49">boxrec-pages/location/people/boxrec.location.people.constants.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L49">boxrec-pages/location/people/boxrec.location.people.constants.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -550,7 +550,7 @@
 					<div class="tsd-signature tsd-kind-icon">Benin<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BJ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L50">boxrec-pages/location/people/boxrec.location.people.constants.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L50">boxrec-pages/location/people/boxrec.location.people.constants.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -560,7 +560,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bermuda<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L51">boxrec-pages/location/people/boxrec.location.people.constants.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L51">boxrec-pages/location/people/boxrec.location.people.constants.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -570,7 +570,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bhutan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L52">boxrec-pages/location/people/boxrec.location.people.constants.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L52">boxrec-pages/location/people/boxrec.location.people.constants.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -580,7 +580,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bolivia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L53">boxrec-pages/location/people/boxrec.location.people.constants.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L53">boxrec-pages/location/people/boxrec.location.people.constants.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -590,7 +590,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bonaire<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BQ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L54">boxrec-pages/location/people/boxrec.location.people.constants.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L54">boxrec-pages/location/people/boxrec.location.people.constants.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -600,7 +600,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bosnia <wbr>And <wbr>Herzegovina<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L55">boxrec-pages/location/people/boxrec.location.people.constants.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L55">boxrec-pages/location/people/boxrec.location.people.constants.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -610,7 +610,7 @@
 					<div class="tsd-signature tsd-kind-icon">Botswana<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L56">boxrec-pages/location/people/boxrec.location.people.constants.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L56">boxrec-pages/location/people/boxrec.location.people.constants.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -620,7 +620,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bouvet <wbr>Island<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BV&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L57">boxrec-pages/location/people/boxrec.location.people.constants.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L57">boxrec-pages/location/people/boxrec.location.people.constants.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -630,7 +630,7 @@
 					<div class="tsd-signature tsd-kind-icon">Brazil<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L58">boxrec-pages/location/people/boxrec.location.people.constants.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L58">boxrec-pages/location/people/boxrec.location.people.constants.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -640,7 +640,7 @@
 					<div class="tsd-signature tsd-kind-icon">British <wbr>Indian <wbr>Ocean <wbr>Territory<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;IO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L59">boxrec-pages/location/people/boxrec.location.people.constants.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L59">boxrec-pages/location/people/boxrec.location.people.constants.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -650,7 +650,7 @@
 					<div class="tsd-signature tsd-kind-icon">British <wbr>Virgin <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;VG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L60">boxrec-pages/location/people/boxrec.location.people.constants.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L60">boxrec-pages/location/people/boxrec.location.people.constants.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -660,7 +660,7 @@
 					<div class="tsd-signature tsd-kind-icon">Brunei<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L61">boxrec-pages/location/people/boxrec.location.people.constants.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L61">boxrec-pages/location/people/boxrec.location.people.constants.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -670,7 +670,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bulgaria<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L62">boxrec-pages/location/people/boxrec.location.people.constants.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L62">boxrec-pages/location/people/boxrec.location.people.constants.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -680,7 +680,7 @@
 					<div class="tsd-signature tsd-kind-icon">Burkina <wbr>Faso<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BF&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L63">boxrec-pages/location/people/boxrec.location.people.constants.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L63">boxrec-pages/location/people/boxrec.location.people.constants.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -690,7 +690,7 @@
 					<div class="tsd-signature tsd-kind-icon">Burundi<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;BI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L64">boxrec-pages/location/people/boxrec.location.people.constants.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L64">boxrec-pages/location/people/boxrec.location.people.constants.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -700,7 +700,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cambodia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L65">boxrec-pages/location/people/boxrec.location.people.constants.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L65">boxrec-pages/location/people/boxrec.location.people.constants.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -710,7 +710,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cameroon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L66">boxrec-pages/location/people/boxrec.location.people.constants.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L66">boxrec-pages/location/people/boxrec.location.people.constants.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -720,7 +720,7 @@
 					<div class="tsd-signature tsd-kind-icon">Canada<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L67">boxrec-pages/location/people/boxrec.location.people.constants.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L67">boxrec-pages/location/people/boxrec.location.people.constants.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -730,7 +730,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cape <wbr>Verde<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CV&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L68">boxrec-pages/location/people/boxrec.location.people.constants.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L68">boxrec-pages/location/people/boxrec.location.people.constants.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -740,7 +740,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cayman <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L69">boxrec-pages/location/people/boxrec.location.people.constants.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L69">boxrec-pages/location/people/boxrec.location.people.constants.ts:69</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -750,7 +750,7 @@
 					<div class="tsd-signature tsd-kind-icon">Central <wbr>African <wbr>Republic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CF&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L70">boxrec-pages/location/people/boxrec.location.people.constants.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L70">boxrec-pages/location/people/boxrec.location.people.constants.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -760,7 +760,7 @@
 					<div class="tsd-signature tsd-kind-icon">Chad<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TD&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L71">boxrec-pages/location/people/boxrec.location.people.constants.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L71">boxrec-pages/location/people/boxrec.location.people.constants.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -770,7 +770,7 @@
 					<div class="tsd-signature tsd-kind-icon">Chile<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L72">boxrec-pages/location/people/boxrec.location.people.constants.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L72">boxrec-pages/location/people/boxrec.location.people.constants.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -780,7 +780,7 @@
 					<div class="tsd-signature tsd-kind-icon">China<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L73">boxrec-pages/location/people/boxrec.location.people.constants.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L73">boxrec-pages/location/people/boxrec.location.people.constants.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -790,7 +790,7 @@
 					<div class="tsd-signature tsd-kind-icon">Christmas <wbr>Island<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CX&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L74">boxrec-pages/location/people/boxrec.location.people.constants.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L74">boxrec-pages/location/people/boxrec.location.people.constants.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -800,7 +800,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cocos (<wbr>Keeling) <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L75">boxrec-pages/location/people/boxrec.location.people.constants.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L75">boxrec-pages/location/people/boxrec.location.people.constants.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -810,7 +810,7 @@
 					<div class="tsd-signature tsd-kind-icon">Colombia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L76">boxrec-pages/location/people/boxrec.location.people.constants.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L76">boxrec-pages/location/people/boxrec.location.people.constants.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -820,7 +820,7 @@
 					<div class="tsd-signature tsd-kind-icon">Comoros<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L77">boxrec-pages/location/people/boxrec.location.people.constants.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L77">boxrec-pages/location/people/boxrec.location.people.constants.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -830,7 +830,7 @@
 					<div class="tsd-signature tsd-kind-icon">Congo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L78">boxrec-pages/location/people/boxrec.location.people.constants.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L78">boxrec-pages/location/people/boxrec.location.people.constants.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -840,7 +840,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cook <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L79">boxrec-pages/location/people/boxrec.location.people.constants.ts:79</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L79">boxrec-pages/location/people/boxrec.location.people.constants.ts:79</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -850,7 +850,7 @@
 					<div class="tsd-signature tsd-kind-icon">Costa <wbr>Rica<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L80">boxrec-pages/location/people/boxrec.location.people.constants.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L80">boxrec-pages/location/people/boxrec.location.people.constants.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -860,7 +860,7 @@
 					<div class="tsd-signature tsd-kind-icon">Croatia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;HR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L81">boxrec-pages/location/people/boxrec.location.people.constants.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L81">boxrec-pages/location/people/boxrec.location.people.constants.ts:81</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -870,7 +870,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cuba<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L82">boxrec-pages/location/people/boxrec.location.people.constants.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L82">boxrec-pages/location/people/boxrec.location.people.constants.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -880,7 +880,7 @@
 					<div class="tsd-signature tsd-kind-icon">Curaçao<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L83">boxrec-pages/location/people/boxrec.location.people.constants.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L83">boxrec-pages/location/people/boxrec.location.people.constants.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -890,7 +890,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cyprus<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L84">boxrec-pages/location/people/boxrec.location.people.constants.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L84">boxrec-pages/location/people/boxrec.location.people.constants.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -900,7 +900,7 @@
 					<div class="tsd-signature tsd-kind-icon">Czech <wbr>Republic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L85">boxrec-pages/location/people/boxrec.location.people.constants.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L85">boxrec-pages/location/people/boxrec.location.people.constants.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -910,7 +910,7 @@
 					<div class="tsd-signature tsd-kind-icon">Côte <wbr>D’Ivoire<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L86">boxrec-pages/location/people/boxrec.location.people.constants.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L86">boxrec-pages/location/people/boxrec.location.people.constants.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -920,7 +920,7 @@
 					<div class="tsd-signature tsd-kind-icon">Democratic <wbr>Republic <wbr>Of <wbr>The <wbr>Congo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CD&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L87">boxrec-pages/location/people/boxrec.location.people.constants.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L87">boxrec-pages/location/people/boxrec.location.people.constants.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -930,7 +930,7 @@
 					<div class="tsd-signature tsd-kind-icon">Denmark<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;DK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L88">boxrec-pages/location/people/boxrec.location.people.constants.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L88">boxrec-pages/location/people/boxrec.location.people.constants.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -940,7 +940,7 @@
 					<div class="tsd-signature tsd-kind-icon">Djibouti<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;DJ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L89">boxrec-pages/location/people/boxrec.location.people.constants.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L89">boxrec-pages/location/people/boxrec.location.people.constants.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -950,7 +950,7 @@
 					<div class="tsd-signature tsd-kind-icon">Dominica<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;DM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L90">boxrec-pages/location/people/boxrec.location.people.constants.ts:90</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L90">boxrec-pages/location/people/boxrec.location.people.constants.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -960,7 +960,7 @@
 					<div class="tsd-signature tsd-kind-icon">Dominican <wbr>Republic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;DO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L91">boxrec-pages/location/people/boxrec.location.people.constants.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L91">boxrec-pages/location/people/boxrec.location.people.constants.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -970,7 +970,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ecuador<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;EC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L92">boxrec-pages/location/people/boxrec.location.people.constants.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L92">boxrec-pages/location/people/boxrec.location.people.constants.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -980,7 +980,7 @@
 					<div class="tsd-signature tsd-kind-icon">Egypt<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;EG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L93">boxrec-pages/location/people/boxrec.location.people.constants.ts:93</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L93">boxrec-pages/location/people/boxrec.location.people.constants.ts:93</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -990,7 +990,7 @@
 					<div class="tsd-signature tsd-kind-icon">El <wbr>Salvador<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SV&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L94">boxrec-pages/location/people/boxrec.location.people.constants.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L94">boxrec-pages/location/people/boxrec.location.people.constants.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1000,7 +1000,7 @@
 					<div class="tsd-signature tsd-kind-icon">Equatorial <wbr>Guinea<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GQ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L95">boxrec-pages/location/people/boxrec.location.people.constants.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L95">boxrec-pages/location/people/boxrec.location.people.constants.ts:95</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1010,7 +1010,7 @@
 					<div class="tsd-signature tsd-kind-icon">Eritrea<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ER&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L96">boxrec-pages/location/people/boxrec.location.people.constants.ts:96</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L96">boxrec-pages/location/people/boxrec.location.people.constants.ts:96</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1020,7 +1020,7 @@
 					<div class="tsd-signature tsd-kind-icon">Estonia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;EE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L97">boxrec-pages/location/people/boxrec.location.people.constants.ts:97</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L97">boxrec-pages/location/people/boxrec.location.people.constants.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1030,7 +1030,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ethiopia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ET&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L98">boxrec-pages/location/people/boxrec.location.people.constants.ts:98</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L98">boxrec-pages/location/people/boxrec.location.people.constants.ts:98</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1040,7 +1040,7 @@
 					<div class="tsd-signature tsd-kind-icon">Falkland <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;FK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L99">boxrec-pages/location/people/boxrec.location.people.constants.ts:99</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L99">boxrec-pages/location/people/boxrec.location.people.constants.ts:99</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1050,7 +1050,7 @@
 					<div class="tsd-signature tsd-kind-icon">Faroe <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;FO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L100">boxrec-pages/location/people/boxrec.location.people.constants.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L100">boxrec-pages/location/people/boxrec.location.people.constants.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1060,7 +1060,7 @@
 					<div class="tsd-signature tsd-kind-icon">Fiji<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;FJ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L101">boxrec-pages/location/people/boxrec.location.people.constants.ts:101</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L101">boxrec-pages/location/people/boxrec.location.people.constants.ts:101</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1070,7 +1070,7 @@
 					<div class="tsd-signature tsd-kind-icon">Finland<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;FI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L102">boxrec-pages/location/people/boxrec.location.people.constants.ts:102</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L102">boxrec-pages/location/people/boxrec.location.people.constants.ts:102</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1080,7 +1080,7 @@
 					<div class="tsd-signature tsd-kind-icon">France<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;FR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L103">boxrec-pages/location/people/boxrec.location.people.constants.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L103">boxrec-pages/location/people/boxrec.location.people.constants.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1090,7 +1090,7 @@
 					<div class="tsd-signature tsd-kind-icon">French <wbr>Guiana<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GF&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L104">boxrec-pages/location/people/boxrec.location.people.constants.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L104">boxrec-pages/location/people/boxrec.location.people.constants.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1100,7 +1100,7 @@
 					<div class="tsd-signature tsd-kind-icon">French <wbr>Polynesia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PF&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L105">boxrec-pages/location/people/boxrec.location.people.constants.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L105">boxrec-pages/location/people/boxrec.location.people.constants.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1110,7 +1110,7 @@
 					<div class="tsd-signature tsd-kind-icon">French <wbr>Southern <wbr>Territories<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TF&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L106">boxrec-pages/location/people/boxrec.location.people.constants.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L106">boxrec-pages/location/people/boxrec.location.people.constants.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1120,7 +1120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Gabon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L107">boxrec-pages/location/people/boxrec.location.people.constants.ts:107</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L107">boxrec-pages/location/people/boxrec.location.people.constants.ts:107</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1130,7 +1130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Gambia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L108">boxrec-pages/location/people/boxrec.location.people.constants.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L108">boxrec-pages/location/people/boxrec.location.people.constants.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1140,7 +1140,7 @@
 					<div class="tsd-signature tsd-kind-icon">Georgia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L109">boxrec-pages/location/people/boxrec.location.people.constants.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L109">boxrec-pages/location/people/boxrec.location.people.constants.ts:109</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1150,7 +1150,7 @@
 					<div class="tsd-signature tsd-kind-icon">Germany<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;DE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L110">boxrec-pages/location/people/boxrec.location.people.constants.ts:110</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L110">boxrec-pages/location/people/boxrec.location.people.constants.ts:110</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1160,7 +1160,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ghana<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L111">boxrec-pages/location/people/boxrec.location.people.constants.ts:111</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L111">boxrec-pages/location/people/boxrec.location.people.constants.ts:111</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1170,7 +1170,7 @@
 					<div class="tsd-signature tsd-kind-icon">Gibraltar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L112">boxrec-pages/location/people/boxrec.location.people.constants.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L112">boxrec-pages/location/people/boxrec.location.people.constants.ts:112</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1180,7 +1180,7 @@
 					<div class="tsd-signature tsd-kind-icon">Greece<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L113">boxrec-pages/location/people/boxrec.location.people.constants.ts:113</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L113">boxrec-pages/location/people/boxrec.location.people.constants.ts:113</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1190,7 +1190,7 @@
 					<div class="tsd-signature tsd-kind-icon">Greenland<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L114">boxrec-pages/location/people/boxrec.location.people.constants.ts:114</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L114">boxrec-pages/location/people/boxrec.location.people.constants.ts:114</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1200,7 +1200,7 @@
 					<div class="tsd-signature tsd-kind-icon">Grenada<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GD&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L115">boxrec-pages/location/people/boxrec.location.people.constants.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L115">boxrec-pages/location/people/boxrec.location.people.constants.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1210,7 +1210,7 @@
 					<div class="tsd-signature tsd-kind-icon">Guadeloupe<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GP&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L116">boxrec-pages/location/people/boxrec.location.people.constants.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L116">boxrec-pages/location/people/boxrec.location.people.constants.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1220,7 +1220,7 @@
 					<div class="tsd-signature tsd-kind-icon">Guam<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L117">boxrec-pages/location/people/boxrec.location.people.constants.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L117">boxrec-pages/location/people/boxrec.location.people.constants.ts:117</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1230,7 +1230,7 @@
 					<div class="tsd-signature tsd-kind-icon">Guatemala<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L118">boxrec-pages/location/people/boxrec.location.people.constants.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L118">boxrec-pages/location/people/boxrec.location.people.constants.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1240,7 +1240,7 @@
 					<div class="tsd-signature tsd-kind-icon">Guinea<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L119">boxrec-pages/location/people/boxrec.location.people.constants.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L119">boxrec-pages/location/people/boxrec.location.people.constants.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1250,7 +1250,7 @@
 					<div class="tsd-signature tsd-kind-icon">Guinea-<wbr><wbr>Bissau<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L120">boxrec-pages/location/people/boxrec.location.people.constants.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L120">boxrec-pages/location/people/boxrec.location.people.constants.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1260,7 +1260,7 @@
 					<div class="tsd-signature tsd-kind-icon">Guyana<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L121">boxrec-pages/location/people/boxrec.location.people.constants.ts:121</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L121">boxrec-pages/location/people/boxrec.location.people.constants.ts:121</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1270,7 +1270,7 @@
 					<div class="tsd-signature tsd-kind-icon">Haiti<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;HT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L122">boxrec-pages/location/people/boxrec.location.people.constants.ts:122</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L122">boxrec-pages/location/people/boxrec.location.people.constants.ts:122</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1280,7 +1280,7 @@
 					<div class="tsd-signature tsd-kind-icon">Heard <wbr>Island <wbr>And <wbr>Mcdonald <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;HM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L123">boxrec-pages/location/people/boxrec.location.people.constants.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L123">boxrec-pages/location/people/boxrec.location.people.constants.ts:123</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1290,7 +1290,7 @@
 					<div class="tsd-signature tsd-kind-icon">Honduras<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;HN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L124">boxrec-pages/location/people/boxrec.location.people.constants.ts:124</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L124">boxrec-pages/location/people/boxrec.location.people.constants.ts:124</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1300,7 +1300,7 @@
 					<div class="tsd-signature tsd-kind-icon">Hong <wbr>Kong <wbr>S.A.<wbr>R.<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;HK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L125">boxrec-pages/location/people/boxrec.location.people.constants.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L125">boxrec-pages/location/people/boxrec.location.people.constants.ts:125</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1310,7 +1310,7 @@
 					<div class="tsd-signature tsd-kind-icon">Hungary<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;HU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L126">boxrec-pages/location/people/boxrec.location.people.constants.ts:126</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L126">boxrec-pages/location/people/boxrec.location.people.constants.ts:126</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1320,7 +1320,7 @@
 					<div class="tsd-signature tsd-kind-icon">Iceland<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;IS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L127">boxrec-pages/location/people/boxrec.location.people.constants.ts:127</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L127">boxrec-pages/location/people/boxrec.location.people.constants.ts:127</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1330,7 +1330,7 @@
 					<div class="tsd-signature tsd-kind-icon">India<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;IN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L128">boxrec-pages/location/people/boxrec.location.people.constants.ts:128</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L128">boxrec-pages/location/people/boxrec.location.people.constants.ts:128</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1340,7 +1340,7 @@
 					<div class="tsd-signature tsd-kind-icon">Indonesia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ID&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L129">boxrec-pages/location/people/boxrec.location.people.constants.ts:129</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L129">boxrec-pages/location/people/boxrec.location.people.constants.ts:129</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1350,7 +1350,7 @@
 					<div class="tsd-signature tsd-kind-icon">Iran<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;IR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L130">boxrec-pages/location/people/boxrec.location.people.constants.ts:130</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L130">boxrec-pages/location/people/boxrec.location.people.constants.ts:130</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1360,7 +1360,7 @@
 					<div class="tsd-signature tsd-kind-icon">Iraq<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;IQ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L131">boxrec-pages/location/people/boxrec.location.people.constants.ts:131</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L131">boxrec-pages/location/people/boxrec.location.people.constants.ts:131</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1370,7 +1370,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ireland<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;IE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L132">boxrec-pages/location/people/boxrec.location.people.constants.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L132">boxrec-pages/location/people/boxrec.location.people.constants.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1380,7 +1380,7 @@
 					<div class="tsd-signature tsd-kind-icon">Israel<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;IL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L133">boxrec-pages/location/people/boxrec.location.people.constants.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L133">boxrec-pages/location/people/boxrec.location.people.constants.ts:133</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1390,7 +1390,7 @@
 					<div class="tsd-signature tsd-kind-icon">Italy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;IT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L134">boxrec-pages/location/people/boxrec.location.people.constants.ts:134</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L134">boxrec-pages/location/people/boxrec.location.people.constants.ts:134</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1400,7 +1400,7 @@
 					<div class="tsd-signature tsd-kind-icon">Jamaica<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;JM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L135">boxrec-pages/location/people/boxrec.location.people.constants.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L135">boxrec-pages/location/people/boxrec.location.people.constants.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1410,7 +1410,7 @@
 					<div class="tsd-signature tsd-kind-icon">Japan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;JP&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L136">boxrec-pages/location/people/boxrec.location.people.constants.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L136">boxrec-pages/location/people/boxrec.location.people.constants.ts:136</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1420,7 +1420,7 @@
 					<div class="tsd-signature tsd-kind-icon">Jordan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;JO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L137">boxrec-pages/location/people/boxrec.location.people.constants.ts:137</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L137">boxrec-pages/location/people/boxrec.location.people.constants.ts:137</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1430,7 +1430,7 @@
 					<div class="tsd-signature tsd-kind-icon">Kazakhstan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L138">boxrec-pages/location/people/boxrec.location.people.constants.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L138">boxrec-pages/location/people/boxrec.location.people.constants.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1440,7 +1440,7 @@
 					<div class="tsd-signature tsd-kind-icon">Kenya<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L139">boxrec-pages/location/people/boxrec.location.people.constants.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L139">boxrec-pages/location/people/boxrec.location.people.constants.ts:139</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1450,7 +1450,7 @@
 					<div class="tsd-signature tsd-kind-icon">Kiribati<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L140">boxrec-pages/location/people/boxrec.location.people.constants.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L140">boxrec-pages/location/people/boxrec.location.people.constants.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1460,7 +1460,7 @@
 					<div class="tsd-signature tsd-kind-icon">Kosovo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;XK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L141">boxrec-pages/location/people/boxrec.location.people.constants.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L141">boxrec-pages/location/people/boxrec.location.people.constants.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1470,7 +1470,7 @@
 					<div class="tsd-signature tsd-kind-icon">Kuwait<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L142">boxrec-pages/location/people/boxrec.location.people.constants.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L142">boxrec-pages/location/people/boxrec.location.people.constants.ts:142</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1480,7 +1480,7 @@
 					<div class="tsd-signature tsd-kind-icon">Kyrgyzstan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L143">boxrec-pages/location/people/boxrec.location.people.constants.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L143">boxrec-pages/location/people/boxrec.location.people.constants.ts:143</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1490,7 +1490,7 @@
 					<div class="tsd-signature tsd-kind-icon">Laos<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L144">boxrec-pages/location/people/boxrec.location.people.constants.ts:144</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L144">boxrec-pages/location/people/boxrec.location.people.constants.ts:144</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1500,7 +1500,7 @@
 					<div class="tsd-signature tsd-kind-icon">Latvia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LV&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L145">boxrec-pages/location/people/boxrec.location.people.constants.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L145">boxrec-pages/location/people/boxrec.location.people.constants.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1510,7 +1510,7 @@
 					<div class="tsd-signature tsd-kind-icon">Lebanon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LB&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L146">boxrec-pages/location/people/boxrec.location.people.constants.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L146">boxrec-pages/location/people/boxrec.location.people.constants.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1520,7 +1520,7 @@
 					<div class="tsd-signature tsd-kind-icon">Lesotho<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L147">boxrec-pages/location/people/boxrec.location.people.constants.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L147">boxrec-pages/location/people/boxrec.location.people.constants.ts:147</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1530,7 +1530,7 @@
 					<div class="tsd-signature tsd-kind-icon">Liberia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L148">boxrec-pages/location/people/boxrec.location.people.constants.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L148">boxrec-pages/location/people/boxrec.location.people.constants.ts:148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1540,7 +1540,7 @@
 					<div class="tsd-signature tsd-kind-icon">Libya<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L149">boxrec-pages/location/people/boxrec.location.people.constants.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L149">boxrec-pages/location/people/boxrec.location.people.constants.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1550,7 +1550,7 @@
 					<div class="tsd-signature tsd-kind-icon">Liechtenstein<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L150">boxrec-pages/location/people/boxrec.location.people.constants.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L150">boxrec-pages/location/people/boxrec.location.people.constants.ts:150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1560,7 +1560,7 @@
 					<div class="tsd-signature tsd-kind-icon">Lithuania<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L151">boxrec-pages/location/people/boxrec.location.people.constants.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L151">boxrec-pages/location/people/boxrec.location.people.constants.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1570,7 +1570,7 @@
 					<div class="tsd-signature tsd-kind-icon">Luxembourg<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L152">boxrec-pages/location/people/boxrec.location.people.constants.ts:152</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L152">boxrec-pages/location/people/boxrec.location.people.constants.ts:152</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1580,7 +1580,7 @@
 					<div class="tsd-signature tsd-kind-icon">Macao <wbr>S.A.<wbr>R.<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L153">boxrec-pages/location/people/boxrec.location.people.constants.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L153">boxrec-pages/location/people/boxrec.location.people.constants.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1590,7 +1590,7 @@
 					<div class="tsd-signature tsd-kind-icon">Macedonia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L154">boxrec-pages/location/people/boxrec.location.people.constants.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L154">boxrec-pages/location/people/boxrec.location.people.constants.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1600,7 +1600,7 @@
 					<div class="tsd-signature tsd-kind-icon">Madagascar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L155">boxrec-pages/location/people/boxrec.location.people.constants.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L155">boxrec-pages/location/people/boxrec.location.people.constants.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1610,7 +1610,7 @@
 					<div class="tsd-signature tsd-kind-icon">Malawi<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L156">boxrec-pages/location/people/boxrec.location.people.constants.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L156">boxrec-pages/location/people/boxrec.location.people.constants.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1620,7 +1620,7 @@
 					<div class="tsd-signature tsd-kind-icon">Malaysia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L157">boxrec-pages/location/people/boxrec.location.people.constants.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L157">boxrec-pages/location/people/boxrec.location.people.constants.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1630,7 +1630,7 @@
 					<div class="tsd-signature tsd-kind-icon">Maldives<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MV&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L158">boxrec-pages/location/people/boxrec.location.people.constants.ts:158</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L158">boxrec-pages/location/people/boxrec.location.people.constants.ts:158</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1640,7 +1640,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mali<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ML&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L159">boxrec-pages/location/people/boxrec.location.people.constants.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L159">boxrec-pages/location/people/boxrec.location.people.constants.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1650,7 +1650,7 @@
 					<div class="tsd-signature tsd-kind-icon">Malta<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L160">boxrec-pages/location/people/boxrec.location.people.constants.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L160">boxrec-pages/location/people/boxrec.location.people.constants.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1660,7 +1660,7 @@
 					<div class="tsd-signature tsd-kind-icon">Marshall <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L161">boxrec-pages/location/people/boxrec.location.people.constants.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L161">boxrec-pages/location/people/boxrec.location.people.constants.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1670,7 +1670,7 @@
 					<div class="tsd-signature tsd-kind-icon">Martinique<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MQ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L162">boxrec-pages/location/people/boxrec.location.people.constants.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L162">boxrec-pages/location/people/boxrec.location.people.constants.ts:162</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1680,7 +1680,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mauritania<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L163">boxrec-pages/location/people/boxrec.location.people.constants.ts:163</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L163">boxrec-pages/location/people/boxrec.location.people.constants.ts:163</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1690,7 +1690,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mauritius<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L164">boxrec-pages/location/people/boxrec.location.people.constants.ts:164</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L164">boxrec-pages/location/people/boxrec.location.people.constants.ts:164</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1700,7 +1700,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mayotte<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;YT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L165">boxrec-pages/location/people/boxrec.location.people.constants.ts:165</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L165">boxrec-pages/location/people/boxrec.location.people.constants.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1710,7 +1710,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mexico<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MX&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L166">boxrec-pages/location/people/boxrec.location.people.constants.ts:166</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L166">boxrec-pages/location/people/boxrec.location.people.constants.ts:166</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1720,7 +1720,7 @@
 					<div class="tsd-signature tsd-kind-icon">Micronesia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;FM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L167">boxrec-pages/location/people/boxrec.location.people.constants.ts:167</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L167">boxrec-pages/location/people/boxrec.location.people.constants.ts:167</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1730,7 +1730,7 @@
 					<div class="tsd-signature tsd-kind-icon">Moldova<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MD&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L168">boxrec-pages/location/people/boxrec.location.people.constants.ts:168</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L168">boxrec-pages/location/people/boxrec.location.people.constants.ts:168</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1740,7 +1740,7 @@
 					<div class="tsd-signature tsd-kind-icon">Monaco<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L169">boxrec-pages/location/people/boxrec.location.people.constants.ts:169</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L169">boxrec-pages/location/people/boxrec.location.people.constants.ts:169</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1750,7 +1750,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mongolia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L170">boxrec-pages/location/people/boxrec.location.people.constants.ts:170</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L170">boxrec-pages/location/people/boxrec.location.people.constants.ts:170</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1760,7 +1760,7 @@
 					<div class="tsd-signature tsd-kind-icon">Montenegro<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ME&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L171">boxrec-pages/location/people/boxrec.location.people.constants.ts:171</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L171">boxrec-pages/location/people/boxrec.location.people.constants.ts:171</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1770,7 +1770,7 @@
 					<div class="tsd-signature tsd-kind-icon">Montserrat<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L172">boxrec-pages/location/people/boxrec.location.people.constants.ts:172</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L172">boxrec-pages/location/people/boxrec.location.people.constants.ts:172</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1780,7 +1780,7 @@
 					<div class="tsd-signature tsd-kind-icon">Morocco<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L173">boxrec-pages/location/people/boxrec.location.people.constants.ts:173</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L173">boxrec-pages/location/people/boxrec.location.people.constants.ts:173</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1790,7 +1790,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mozambique<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L174">boxrec-pages/location/people/boxrec.location.people.constants.ts:174</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L174">boxrec-pages/location/people/boxrec.location.people.constants.ts:174</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1800,7 +1800,7 @@
 					<div class="tsd-signature tsd-kind-icon">Myanmar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L175">boxrec-pages/location/people/boxrec.location.people.constants.ts:175</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L175">boxrec-pages/location/people/boxrec.location.people.constants.ts:175</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1810,7 +1810,7 @@
 					<div class="tsd-signature tsd-kind-icon">Namibia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L176">boxrec-pages/location/people/boxrec.location.people.constants.ts:176</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L176">boxrec-pages/location/people/boxrec.location.people.constants.ts:176</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1820,7 +1820,7 @@
 					<div class="tsd-signature tsd-kind-icon">Nauru<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L177">boxrec-pages/location/people/boxrec.location.people.constants.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L177">boxrec-pages/location/people/boxrec.location.people.constants.ts:177</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1830,7 +1830,7 @@
 					<div class="tsd-signature tsd-kind-icon">Nepal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NP&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L178">boxrec-pages/location/people/boxrec.location.people.constants.ts:178</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L178">boxrec-pages/location/people/boxrec.location.people.constants.ts:178</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1840,7 +1840,7 @@
 					<div class="tsd-signature tsd-kind-icon">Netherlands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L179">boxrec-pages/location/people/boxrec.location.people.constants.ts:179</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L179">boxrec-pages/location/people/boxrec.location.people.constants.ts:179</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1850,7 +1850,7 @@
 					<div class="tsd-signature tsd-kind-icon">Netherlands <wbr>Antilles<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L180">boxrec-pages/location/people/boxrec.location.people.constants.ts:180</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L180">boxrec-pages/location/people/boxrec.location.people.constants.ts:180</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1860,7 +1860,7 @@
 					<div class="tsd-signature tsd-kind-icon">New <wbr>Caledonia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L181">boxrec-pages/location/people/boxrec.location.people.constants.ts:181</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L181">boxrec-pages/location/people/boxrec.location.people.constants.ts:181</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1870,7 +1870,7 @@
 					<div class="tsd-signature tsd-kind-icon">New <wbr>Zealand<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L182">boxrec-pages/location/people/boxrec.location.people.constants.ts:182</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L182">boxrec-pages/location/people/boxrec.location.people.constants.ts:182</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1880,7 +1880,7 @@
 					<div class="tsd-signature tsd-kind-icon">Nicaragua<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L183">boxrec-pages/location/people/boxrec.location.people.constants.ts:183</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L183">boxrec-pages/location/people/boxrec.location.people.constants.ts:183</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1890,7 +1890,7 @@
 					<div class="tsd-signature tsd-kind-icon">Niger<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L184">boxrec-pages/location/people/boxrec.location.people.constants.ts:184</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L184">boxrec-pages/location/people/boxrec.location.people.constants.ts:184</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1900,7 +1900,7 @@
 					<div class="tsd-signature tsd-kind-icon">Nigeria<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L185">boxrec-pages/location/people/boxrec.location.people.constants.ts:185</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L185">boxrec-pages/location/people/boxrec.location.people.constants.ts:185</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1910,7 +1910,7 @@
 					<div class="tsd-signature tsd-kind-icon">Niue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L186">boxrec-pages/location/people/boxrec.location.people.constants.ts:186</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L186">boxrec-pages/location/people/boxrec.location.people.constants.ts:186</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1920,7 +1920,7 @@
 					<div class="tsd-signature tsd-kind-icon">Norfolk <wbr>Island<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NF&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L187">boxrec-pages/location/people/boxrec.location.people.constants.ts:187</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L187">boxrec-pages/location/people/boxrec.location.people.constants.ts:187</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1930,7 +1930,7 @@
 					<div class="tsd-signature tsd-kind-icon">North <wbr>Korea<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KP&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L188">boxrec-pages/location/people/boxrec.location.people.constants.ts:188</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L188">boxrec-pages/location/people/boxrec.location.people.constants.ts:188</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1940,7 +1940,7 @@
 					<div class="tsd-signature tsd-kind-icon">Northern <wbr>Mariana <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;MP&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L189">boxrec-pages/location/people/boxrec.location.people.constants.ts:189</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L189">boxrec-pages/location/people/boxrec.location.people.constants.ts:189</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1950,7 +1950,7 @@
 					<div class="tsd-signature tsd-kind-icon">Norway<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;NO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L190">boxrec-pages/location/people/boxrec.location.people.constants.ts:190</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L190">boxrec-pages/location/people/boxrec.location.people.constants.ts:190</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1960,7 +1960,7 @@
 					<div class="tsd-signature tsd-kind-icon">Oman<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;OM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L191">boxrec-pages/location/people/boxrec.location.people.constants.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L191">boxrec-pages/location/people/boxrec.location.people.constants.ts:191</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1970,7 +1970,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pakistan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L192">boxrec-pages/location/people/boxrec.location.people.constants.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L192">boxrec-pages/location/people/boxrec.location.people.constants.ts:192</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1980,7 +1980,7 @@
 					<div class="tsd-signature tsd-kind-icon">Palau<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L193">boxrec-pages/location/people/boxrec.location.people.constants.ts:193</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L193">boxrec-pages/location/people/boxrec.location.people.constants.ts:193</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1990,7 +1990,7 @@
 					<div class="tsd-signature tsd-kind-icon">Palestinian <wbr>Territory<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L194">boxrec-pages/location/people/boxrec.location.people.constants.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L194">boxrec-pages/location/people/boxrec.location.people.constants.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2000,7 +2000,7 @@
 					<div class="tsd-signature tsd-kind-icon">Panama<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L195">boxrec-pages/location/people/boxrec.location.people.constants.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L195">boxrec-pages/location/people/boxrec.location.people.constants.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2010,7 +2010,7 @@
 					<div class="tsd-signature tsd-kind-icon">Papua <wbr>New <wbr>Guinea<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L196">boxrec-pages/location/people/boxrec.location.people.constants.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L196">boxrec-pages/location/people/boxrec.location.people.constants.ts:196</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2020,7 +2020,7 @@
 					<div class="tsd-signature tsd-kind-icon">Paraguay<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L197">boxrec-pages/location/people/boxrec.location.people.constants.ts:197</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L197">boxrec-pages/location/people/boxrec.location.people.constants.ts:197</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2030,7 +2030,7 @@
 					<div class="tsd-signature tsd-kind-icon">Peru<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L198">boxrec-pages/location/people/boxrec.location.people.constants.ts:198</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L198">boxrec-pages/location/people/boxrec.location.people.constants.ts:198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2040,7 +2040,7 @@
 					<div class="tsd-signature tsd-kind-icon">Philippines<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L199">boxrec-pages/location/people/boxrec.location.people.constants.ts:199</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L199">boxrec-pages/location/people/boxrec.location.people.constants.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2050,7 +2050,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pitcairn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L200">boxrec-pages/location/people/boxrec.location.people.constants.ts:200</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L200">boxrec-pages/location/people/boxrec.location.people.constants.ts:200</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2060,7 +2060,7 @@
 					<div class="tsd-signature tsd-kind-icon">Poland<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L201">boxrec-pages/location/people/boxrec.location.people.constants.ts:201</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L201">boxrec-pages/location/people/boxrec.location.people.constants.ts:201</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2070,7 +2070,7 @@
 					<div class="tsd-signature tsd-kind-icon">Portugal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L202">boxrec-pages/location/people/boxrec.location.people.constants.ts:202</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L202">boxrec-pages/location/people/boxrec.location.people.constants.ts:202</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2080,7 +2080,7 @@
 					<div class="tsd-signature tsd-kind-icon">Puerto <wbr>Rico<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L203">boxrec-pages/location/people/boxrec.location.people.constants.ts:203</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L203">boxrec-pages/location/people/boxrec.location.people.constants.ts:203</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2090,7 +2090,7 @@
 					<div class="tsd-signature tsd-kind-icon">Qatar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;QA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L204">boxrec-pages/location/people/boxrec.location.people.constants.ts:204</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L204">boxrec-pages/location/people/boxrec.location.people.constants.ts:204</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2100,7 +2100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Romania<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;RO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L205">boxrec-pages/location/people/boxrec.location.people.constants.ts:205</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L205">boxrec-pages/location/people/boxrec.location.people.constants.ts:205</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2110,7 +2110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Russia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;RU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L206">boxrec-pages/location/people/boxrec.location.people.constants.ts:206</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L206">boxrec-pages/location/people/boxrec.location.people.constants.ts:206</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2120,7 +2120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Rwanda<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;RW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L207">boxrec-pages/location/people/boxrec.location.people.constants.ts:207</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L207">boxrec-pages/location/people/boxrec.location.people.constants.ts:207</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2130,7 +2130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Réunion<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;RE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L208">boxrec-pages/location/people/boxrec.location.people.constants.ts:208</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L208">boxrec-pages/location/people/boxrec.location.people.constants.ts:208</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2140,7 +2140,7 @@
 					<div class="tsd-signature tsd-kind-icon">Saint <wbr>Helena<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L209">boxrec-pages/location/people/boxrec.location.people.constants.ts:209</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L209">boxrec-pages/location/people/boxrec.location.people.constants.ts:209</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2150,7 +2150,7 @@
 					<div class="tsd-signature tsd-kind-icon">Saint <wbr>Kitts <wbr>And <wbr>Nevis<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L210">boxrec-pages/location/people/boxrec.location.people.constants.ts:210</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L210">boxrec-pages/location/people/boxrec.location.people.constants.ts:210</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2160,7 +2160,7 @@
 					<div class="tsd-signature tsd-kind-icon">Saint <wbr>Lucia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L211">boxrec-pages/location/people/boxrec.location.people.constants.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L211">boxrec-pages/location/people/boxrec.location.people.constants.ts:211</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2170,7 +2170,7 @@
 					<div class="tsd-signature tsd-kind-icon">Saint <wbr>Pierre <wbr>And <wbr>Miquelon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;PM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L212">boxrec-pages/location/people/boxrec.location.people.constants.ts:212</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L212">boxrec-pages/location/people/boxrec.location.people.constants.ts:212</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2180,7 +2180,7 @@
 					<div class="tsd-signature tsd-kind-icon">Saint <wbr>Vincent <wbr>And <wbr>The <wbr>Grenadines<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;VC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L213">boxrec-pages/location/people/boxrec.location.people.constants.ts:213</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L213">boxrec-pages/location/people/boxrec.location.people.constants.ts:213</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2190,7 +2190,7 @@
 					<div class="tsd-signature tsd-kind-icon">Samoa<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;WS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L214">boxrec-pages/location/people/boxrec.location.people.constants.ts:214</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L214">boxrec-pages/location/people/boxrec.location.people.constants.ts:214</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2200,7 +2200,7 @@
 					<div class="tsd-signature tsd-kind-icon">San <wbr>Marino<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L215">boxrec-pages/location/people/boxrec.location.people.constants.ts:215</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L215">boxrec-pages/location/people/boxrec.location.people.constants.ts:215</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2210,7 +2210,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sao <wbr>Tome <wbr>And <wbr>Principe<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ST&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L216">boxrec-pages/location/people/boxrec.location.people.constants.ts:216</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L216">boxrec-pages/location/people/boxrec.location.people.constants.ts:216</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2220,7 +2220,7 @@
 					<div class="tsd-signature tsd-kind-icon">Saudi <wbr>Arabia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L217">boxrec-pages/location/people/boxrec.location.people.constants.ts:217</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L217">boxrec-pages/location/people/boxrec.location.people.constants.ts:217</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2230,7 +2230,7 @@
 					<div class="tsd-signature tsd-kind-icon">Senegal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L218">boxrec-pages/location/people/boxrec.location.people.constants.ts:218</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L218">boxrec-pages/location/people/boxrec.location.people.constants.ts:218</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2240,7 +2240,7 @@
 					<div class="tsd-signature tsd-kind-icon">Serbia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;RS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L219">boxrec-pages/location/people/boxrec.location.people.constants.ts:219</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L219">boxrec-pages/location/people/boxrec.location.people.constants.ts:219</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2250,7 +2250,7 @@
 					<div class="tsd-signature tsd-kind-icon">Seychelles<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L220">boxrec-pages/location/people/boxrec.location.people.constants.ts:220</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L220">boxrec-pages/location/people/boxrec.location.people.constants.ts:220</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2260,7 +2260,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sierra <wbr>Leone<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L221">boxrec-pages/location/people/boxrec.location.people.constants.ts:221</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L221">boxrec-pages/location/people/boxrec.location.people.constants.ts:221</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2270,7 +2270,7 @@
 					<div class="tsd-signature tsd-kind-icon">Singapore<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L222">boxrec-pages/location/people/boxrec.location.people.constants.ts:222</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L222">boxrec-pages/location/people/boxrec.location.people.constants.ts:222</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2280,7 +2280,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sint <wbr>Maarten<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SX&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L223">boxrec-pages/location/people/boxrec.location.people.constants.ts:223</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L223">boxrec-pages/location/people/boxrec.location.people.constants.ts:223</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2290,7 +2290,7 @@
 					<div class="tsd-signature tsd-kind-icon">Slovakia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L224">boxrec-pages/location/people/boxrec.location.people.constants.ts:224</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L224">boxrec-pages/location/people/boxrec.location.people.constants.ts:224</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2300,7 +2300,7 @@
 					<div class="tsd-signature tsd-kind-icon">Slovenia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L225">boxrec-pages/location/people/boxrec.location.people.constants.ts:225</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L225">boxrec-pages/location/people/boxrec.location.people.constants.ts:225</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2310,7 +2310,7 @@
 					<div class="tsd-signature tsd-kind-icon">Solomon <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SB&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L226">boxrec-pages/location/people/boxrec.location.people.constants.ts:226</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L226">boxrec-pages/location/people/boxrec.location.people.constants.ts:226</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2320,7 +2320,7 @@
 					<div class="tsd-signature tsd-kind-icon">Somalia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L227">boxrec-pages/location/people/boxrec.location.people.constants.ts:227</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L227">boxrec-pages/location/people/boxrec.location.people.constants.ts:227</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2330,7 +2330,7 @@
 					<div class="tsd-signature tsd-kind-icon">South <wbr>Africa<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ZA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L228">boxrec-pages/location/people/boxrec.location.people.constants.ts:228</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L228">boxrec-pages/location/people/boxrec.location.people.constants.ts:228</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2340,7 +2340,7 @@
 					<div class="tsd-signature tsd-kind-icon">South <wbr>Georgia <wbr>And <wbr>The <wbr>South <wbr>Sandwich <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;GS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L229">boxrec-pages/location/people/boxrec.location.people.constants.ts:229</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L229">boxrec-pages/location/people/boxrec.location.people.constants.ts:229</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2350,7 +2350,7 @@
 					<div class="tsd-signature tsd-kind-icon">South <wbr>Korea<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;KR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L230">boxrec-pages/location/people/boxrec.location.people.constants.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L230">boxrec-pages/location/people/boxrec.location.people.constants.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2360,7 +2360,7 @@
 					<div class="tsd-signature tsd-kind-icon">South <wbr>Sudan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L231">boxrec-pages/location/people/boxrec.location.people.constants.ts:231</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L231">boxrec-pages/location/people/boxrec.location.people.constants.ts:231</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2370,7 +2370,7 @@
 					<div class="tsd-signature tsd-kind-icon">Spain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ES&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L232">boxrec-pages/location/people/boxrec.location.people.constants.ts:232</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L232">boxrec-pages/location/people/boxrec.location.people.constants.ts:232</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2380,7 +2380,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sri <wbr>Lanka<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;LK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L233">boxrec-pages/location/people/boxrec.location.people.constants.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L233">boxrec-pages/location/people/boxrec.location.people.constants.ts:233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2390,7 +2390,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sudan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SD&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L234">boxrec-pages/location/people/boxrec.location.people.constants.ts:234</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L234">boxrec-pages/location/people/boxrec.location.people.constants.ts:234</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2400,7 +2400,7 @@
 					<div class="tsd-signature tsd-kind-icon">Suriname<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L235">boxrec-pages/location/people/boxrec.location.people.constants.ts:235</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L235">boxrec-pages/location/people/boxrec.location.people.constants.ts:235</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2410,7 +2410,7 @@
 					<div class="tsd-signature tsd-kind-icon">Svalbard <wbr>And <wbr>Jan <wbr>Mayen<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SJ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L236">boxrec-pages/location/people/boxrec.location.people.constants.ts:236</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L236">boxrec-pages/location/people/boxrec.location.people.constants.ts:236</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2420,7 +2420,7 @@
 					<div class="tsd-signature tsd-kind-icon">Swaziland<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L237">boxrec-pages/location/people/boxrec.location.people.constants.ts:237</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L237">boxrec-pages/location/people/boxrec.location.people.constants.ts:237</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2430,7 +2430,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sweden<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L238">boxrec-pages/location/people/boxrec.location.people.constants.ts:238</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L238">boxrec-pages/location/people/boxrec.location.people.constants.ts:238</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2440,7 +2440,7 @@
 					<div class="tsd-signature tsd-kind-icon">Switzerland<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;CH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L239">boxrec-pages/location/people/boxrec.location.people.constants.ts:239</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L239">boxrec-pages/location/people/boxrec.location.people.constants.ts:239</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2450,7 +2450,7 @@
 					<div class="tsd-signature tsd-kind-icon">Syria<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L240">boxrec-pages/location/people/boxrec.location.people.constants.ts:240</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L240">boxrec-pages/location/people/boxrec.location.people.constants.ts:240</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2460,7 +2460,7 @@
 					<div class="tsd-signature tsd-kind-icon">Taiwan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L241">boxrec-pages/location/people/boxrec.location.people.constants.ts:241</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L241">boxrec-pages/location/people/boxrec.location.people.constants.ts:241</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2470,7 +2470,7 @@
 					<div class="tsd-signature tsd-kind-icon">Tajikistan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TJ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L242">boxrec-pages/location/people/boxrec.location.people.constants.ts:242</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L242">boxrec-pages/location/people/boxrec.location.people.constants.ts:242</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2480,7 +2480,7 @@
 					<div class="tsd-signature tsd-kind-icon">Tanzania<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L243">boxrec-pages/location/people/boxrec.location.people.constants.ts:243</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L243">boxrec-pages/location/people/boxrec.location.people.constants.ts:243</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2490,7 +2490,7 @@
 					<div class="tsd-signature tsd-kind-icon">Thailand<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L244">boxrec-pages/location/people/boxrec.location.people.constants.ts:244</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L244">boxrec-pages/location/people/boxrec.location.people.constants.ts:244</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2500,7 +2500,7 @@
 					<div class="tsd-signature tsd-kind-icon">Timor-<wbr><wbr>Leste<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L245">boxrec-pages/location/people/boxrec.location.people.constants.ts:245</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L245">boxrec-pages/location/people/boxrec.location.people.constants.ts:245</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2510,7 +2510,7 @@
 					<div class="tsd-signature tsd-kind-icon">Togo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L246">boxrec-pages/location/people/boxrec.location.people.constants.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L246">boxrec-pages/location/people/boxrec.location.people.constants.ts:246</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2520,7 +2520,7 @@
 					<div class="tsd-signature tsd-kind-icon">Tokelau<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L247">boxrec-pages/location/people/boxrec.location.people.constants.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L247">boxrec-pages/location/people/boxrec.location.people.constants.ts:247</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2530,7 +2530,7 @@
 					<div class="tsd-signature tsd-kind-icon">Tonga<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TO&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L248">boxrec-pages/location/people/boxrec.location.people.constants.ts:248</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L248">boxrec-pages/location/people/boxrec.location.people.constants.ts:248</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2540,7 +2540,7 @@
 					<div class="tsd-signature tsd-kind-icon">Trinidad <wbr>And <wbr>Tobago<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L249">boxrec-pages/location/people/boxrec.location.people.constants.ts:249</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L249">boxrec-pages/location/people/boxrec.location.people.constants.ts:249</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2550,7 +2550,7 @@
 					<div class="tsd-signature tsd-kind-icon">Tunisia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L250">boxrec-pages/location/people/boxrec.location.people.constants.ts:250</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L250">boxrec-pages/location/people/boxrec.location.people.constants.ts:250</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2560,7 +2560,7 @@
 					<div class="tsd-signature tsd-kind-icon">Turkey<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L251">boxrec-pages/location/people/boxrec.location.people.constants.ts:251</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L251">boxrec-pages/location/people/boxrec.location.people.constants.ts:251</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2570,7 +2570,7 @@
 					<div class="tsd-signature tsd-kind-icon">Turkmenistan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L252">boxrec-pages/location/people/boxrec.location.people.constants.ts:252</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L252">boxrec-pages/location/people/boxrec.location.people.constants.ts:252</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2580,7 +2580,7 @@
 					<div class="tsd-signature tsd-kind-icon">Turks <wbr>And <wbr>Caicos <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L253">boxrec-pages/location/people/boxrec.location.people.constants.ts:253</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L253">boxrec-pages/location/people/boxrec.location.people.constants.ts:253</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2590,7 +2590,7 @@
 					<div class="tsd-signature tsd-kind-icon">Tuvalu<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;TV&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L254">boxrec-pages/location/people/boxrec.location.people.constants.ts:254</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L254">boxrec-pages/location/people/boxrec.location.people.constants.ts:254</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2600,7 +2600,7 @@
 					<div class="tsd-signature tsd-kind-icon">U.<wbr>S. <wbr>Virgin <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;VI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L255">boxrec-pages/location/people/boxrec.location.people.constants.ts:255</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L255">boxrec-pages/location/people/boxrec.location.people.constants.ts:255</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2610,7 +2610,7 @@
 					<div class="tsd-signature tsd-kind-icon">USA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;US&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L262">boxrec-pages/location/people/boxrec.location.people.constants.ts:262</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L262">boxrec-pages/location/people/boxrec.location.people.constants.ts:262</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2620,7 +2620,7 @@
 					<div class="tsd-signature tsd-kind-icon">Uganda<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;UG&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L256">boxrec-pages/location/people/boxrec.location.people.constants.ts:256</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L256">boxrec-pages/location/people/boxrec.location.people.constants.ts:256</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2630,7 +2630,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ukraine<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;UA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L257">boxrec-pages/location/people/boxrec.location.people.constants.ts:257</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L257">boxrec-pages/location/people/boxrec.location.people.constants.ts:257</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2640,7 +2640,7 @@
 					<div class="tsd-signature tsd-kind-icon">United <wbr>Arab <wbr>Emirates<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;AE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L258">boxrec-pages/location/people/boxrec.location.people.constants.ts:258</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L258">boxrec-pages/location/people/boxrec.location.people.constants.ts:258</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2650,7 +2650,7 @@
 					<div class="tsd-signature tsd-kind-icon">United <wbr>Kingdom<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;UK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L259">boxrec-pages/location/people/boxrec.location.people.constants.ts:259</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L259">boxrec-pages/location/people/boxrec.location.people.constants.ts:259</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2660,7 +2660,7 @@
 					<div class="tsd-signature tsd-kind-icon">United <wbr>States <wbr>Minor <wbr>Outlying <wbr>Islands<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;UM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L260">boxrec-pages/location/people/boxrec.location.people.constants.ts:260</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L260">boxrec-pages/location/people/boxrec.location.people.constants.ts:260</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2670,7 +2670,7 @@
 					<div class="tsd-signature tsd-kind-icon">Uruguay<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;UY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L261">boxrec-pages/location/people/boxrec.location.people.constants.ts:261</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L261">boxrec-pages/location/people/boxrec.location.people.constants.ts:261</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2680,7 +2680,7 @@
 					<div class="tsd-signature tsd-kind-icon">Uzbekistan<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;UZ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L263">boxrec-pages/location/people/boxrec.location.people.constants.ts:263</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L263">boxrec-pages/location/people/boxrec.location.people.constants.ts:263</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2690,7 +2690,7 @@
 					<div class="tsd-signature tsd-kind-icon">Vanuatu<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;VU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L264">boxrec-pages/location/people/boxrec.location.people.constants.ts:264</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L264">boxrec-pages/location/people/boxrec.location.people.constants.ts:264</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2700,7 +2700,7 @@
 					<div class="tsd-signature tsd-kind-icon">Vatican<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;VA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L265">boxrec-pages/location/people/boxrec.location.people.constants.ts:265</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L265">boxrec-pages/location/people/boxrec.location.people.constants.ts:265</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2710,7 +2710,7 @@
 					<div class="tsd-signature tsd-kind-icon">Venezuela<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;VE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L266">boxrec-pages/location/people/boxrec.location.people.constants.ts:266</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L266">boxrec-pages/location/people/boxrec.location.people.constants.ts:266</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2720,7 +2720,7 @@
 					<div class="tsd-signature tsd-kind-icon">Vietnam<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;VN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L267">boxrec-pages/location/people/boxrec.location.people.constants.ts:267</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L267">boxrec-pages/location/people/boxrec.location.people.constants.ts:267</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2730,7 +2730,7 @@
 					<div class="tsd-signature tsd-kind-icon">Wallis <wbr>And <wbr>Futuna<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;WF&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L268">boxrec-pages/location/people/boxrec.location.people.constants.ts:268</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L268">boxrec-pages/location/people/boxrec.location.people.constants.ts:268</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2740,7 +2740,7 @@
 					<div class="tsd-signature tsd-kind-icon">Western <wbr>Sahara<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;EH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L269">boxrec-pages/location/people/boxrec.location.people.constants.ts:269</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L269">boxrec-pages/location/people/boxrec.location.people.constants.ts:269</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2750,7 +2750,7 @@
 					<div class="tsd-signature tsd-kind-icon">Yemen<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;YE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L270">boxrec-pages/location/people/boxrec.location.people.constants.ts:270</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L270">boxrec-pages/location/people/boxrec.location.people.constants.ts:270</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2760,7 +2760,7 @@
 					<div class="tsd-signature tsd-kind-icon">Yugoslavia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;YU&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L271">boxrec-pages/location/people/boxrec.location.people.constants.ts:271</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L271">boxrec-pages/location/people/boxrec.location.people.constants.ts:271</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2770,7 +2770,7 @@
 					<div class="tsd-signature tsd-kind-icon">Zambia<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ZM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L272">boxrec-pages/location/people/boxrec.location.people.constants.ts:272</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L272">boxrec-pages/location/people/boxrec.location.people.constants.ts:272</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -2780,7 +2780,7 @@
 					<div class="tsd-signature tsd-kind-icon">Zimbabwe<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ZW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L273">boxrec-pages/location/people/boxrec.location.people.constants.ts:273</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L273">boxrec-pages/location/people/boxrec.location.people.constants.ts:273</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/weightdivision.html
+++ b/docs/enums/weightdivision.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">bantamweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;bantamweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L60">boxrec-pages/champions/boxrec.champions.constants.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L60">boxrec-pages/champions/boxrec.champions.constants.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">cruiserweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;cruiserweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L49">boxrec-pages/champions/boxrec.champions.constants.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L49">boxrec-pages/champions/boxrec.champions.constants.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">featherweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;featherweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L58">boxrec-pages/champions/boxrec.champions.constants.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L58">boxrec-pages/champions/boxrec.champions.constants.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">flyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;flyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L62">boxrec-pages/champions/boxrec.champions.constants.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L62">boxrec-pages/champions/boxrec.champions.constants.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">heavyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;heavyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L48">boxrec-pages/champions/boxrec.champions.constants.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L48">boxrec-pages/champions/boxrec.champions.constants.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">light<wbr>Flyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;light flyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L63">boxrec-pages/champions/boxrec.champions.constants.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L63">boxrec-pages/champions/boxrec.champions.constants.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">light<wbr>Heavyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;light heavyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L50">boxrec-pages/champions/boxrec.champions.constants.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L50">boxrec-pages/champions/boxrec.champions.constants.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">lightweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;lightweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L56">boxrec-pages/champions/boxrec.champions.constants.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L56">boxrec-pages/champions/boxrec.champions.constants.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">middleweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;middleweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L52">boxrec-pages/champions/boxrec.champions.constants.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L52">boxrec-pages/champions/boxrec.champions.constants.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">minimumweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;minimumweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L64">boxrec-pages/champions/boxrec.champions.constants.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L64">boxrec-pages/champions/boxrec.champions.constants.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Bantamweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;super bantamweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L59">boxrec-pages/champions/boxrec.champions.constants.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L59">boxrec-pages/champions/boxrec.champions.constants.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Featherweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;super featherweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L57">boxrec-pages/champions/boxrec.champions.constants.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L57">boxrec-pages/champions/boxrec.champions.constants.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Flyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;super flyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L61">boxrec-pages/champions/boxrec.champions.constants.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L61">boxrec-pages/champions/boxrec.champions.constants.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -231,7 +231,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Lightweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;super lightweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L55">boxrec-pages/champions/boxrec.champions.constants.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L55">boxrec-pages/champions/boxrec.champions.constants.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Middleweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;super middleweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L51">boxrec-pages/champions/boxrec.champions.constants.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L51">boxrec-pages/champions/boxrec.champions.constants.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -251,7 +251,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Welterweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;super welterweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L53">boxrec-pages/champions/boxrec.champions.constants.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L53">boxrec-pages/champions/boxrec.champions.constants.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -261,7 +261,7 @@
 					<div class="tsd-signature tsd-kind-icon">welterweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;welterweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L54">boxrec-pages/champions/boxrec.champions.constants.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L54">boxrec-pages/champions/boxrec.champions.constants.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/weightdivisioncapitalized.html
+++ b/docs/enums/weightdivisioncapitalized.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">bantamweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Bantamweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L17">boxrec-pages/titles/boxrec.page.title.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L17">boxrec-pages/titles/boxrec.page.title.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">cruiserweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Cruiserweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L6">boxrec-pages/titles/boxrec.page.title.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L6">boxrec-pages/titles/boxrec.page.title.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">featherweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Featherweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L15">boxrec-pages/titles/boxrec.page.title.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L15">boxrec-pages/titles/boxrec.page.title.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">flyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Flyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L19">boxrec-pages/titles/boxrec.page.title.constants.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L19">boxrec-pages/titles/boxrec.page.title.constants.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">heavyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Heavyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L5">boxrec-pages/titles/boxrec.page.title.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L5">boxrec-pages/titles/boxrec.page.title.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">light<wbr>Flyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Light Flyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L20">boxrec-pages/titles/boxrec.page.title.constants.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L20">boxrec-pages/titles/boxrec.page.title.constants.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">light<wbr>Heavyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Light Heavyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L7">boxrec-pages/titles/boxrec.page.title.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L7">boxrec-pages/titles/boxrec.page.title.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">lightweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Lightweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L13">boxrec-pages/titles/boxrec.page.title.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L13">boxrec-pages/titles/boxrec.page.title.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">middleweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Middleweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L9">boxrec-pages/titles/boxrec.page.title.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L9">boxrec-pages/titles/boxrec.page.title.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">minimumweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Minimumweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L21">boxrec-pages/titles/boxrec.page.title.constants.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L21">boxrec-pages/titles/boxrec.page.title.constants.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Bantamweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Super Bantamweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L16">boxrec-pages/titles/boxrec.page.title.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L16">boxrec-pages/titles/boxrec.page.title.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Featherweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Super Featherweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L14">boxrec-pages/titles/boxrec.page.title.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L14">boxrec-pages/titles/boxrec.page.title.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Flyweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Super Flyweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L18">boxrec-pages/titles/boxrec.page.title.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L18">boxrec-pages/titles/boxrec.page.title.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -231,7 +231,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Lightweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Super Lightweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L12">boxrec-pages/titles/boxrec.page.title.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L12">boxrec-pages/titles/boxrec.page.title.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Middleweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Super Middleweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L8">boxrec-pages/titles/boxrec.page.title.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L8">boxrec-pages/titles/boxrec.page.title.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -251,7 +251,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Welterweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Super Welterweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L10">boxrec-pages/titles/boxrec.page.title.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L10">boxrec-pages/titles/boxrec.page.title.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -261,7 +261,7 @@
 					<div class="tsd-signature tsd-kind-icon">welterweight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Welterweight&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L11">boxrec-pages/titles/boxrec.page.title.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L11">boxrec-pages/titles/boxrec.page.title.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/winlossdraw.html
+++ b/docs/enums/winlossdraw.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">draw<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;draw&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L20">boxrec-pages/boxrec.constants.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L20">boxrec-pages/boxrec.constants.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">loss<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;loss&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L19">boxrec-pages/boxrec.constants.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L19">boxrec-pages/boxrec.constants.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">scheduled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;scheduled&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L21">boxrec-pages/boxrec.constants.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L21">boxrec-pages/boxrec.constants.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L22">boxrec-pages/boxrec.constants.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L22">boxrec-pages/boxrec.constants.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">win<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;win&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L18">boxrec-pages/boxrec.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L18">boxrec-pages/boxrec.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -231,7 +231,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"orthodox"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"southpaw"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L62">boxrec-pages/boxrec.constants.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L62">boxrec-pages/boxrec.constants.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -244,8 +244,8 @@
 					<div class="tsd-signature tsd-kind-icon">$<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CheerioStatic</span><span class="tsd-signature-symbol"> =&nbsp;cheerio.load(&quot;&lt;div&gt;&lt;/div&gt;&quot;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-links.ts#L3">boxrec-common-tables/boxrec-common-links.ts:3</a></li>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L10">boxrec-common-tables/boxrec-common-tables-columns.class.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-links.ts#L3">boxrec-common-tables/boxrec-common-links.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts#L10">boxrec-common-tables/boxrec-common-tables-columns.class.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -255,7 +255,7 @@
 					<div class="tsd-signature tsd-kind-icon">town<wbr>Region<wbr>Country<wbr>Regex<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> =&nbsp;/\?country&#x3D;([A-Za-z]+)(?:(?:&amp;|&amp;amp;)region&#x3D;([A-Za-z0-9]*))?(?:(?:&amp;|&amp;amp;)town&#x3D;(\d+))?/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/helpers.ts#L63">helpers.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/helpers.ts#L63">helpers.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/helpers.ts#L37">helpers.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/helpers.ts#L37">helpers.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -305,7 +305,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/helpers.ts#L6">helpers.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/helpers.ts#L6">helpers.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -333,7 +333,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/helpers.ts#L49">helpers.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/helpers.ts#L49">helpers.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -376,7 +376,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/helpers.ts#L71">helpers.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/helpers.ts#L71">helpers.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -404,7 +404,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/helpers.ts#L27">helpers.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/helpers.ts#L27">helpers.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -431,7 +431,7 @@
 					<div class="tsd-signature tsd-kind-icon">belt<wbr>Organizations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L12">boxrec-pages/champions/boxrec.page.champions.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L12">boxrec-pages/champions/boxrec.page.champions.ts:12</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal tsd-is-not-exported">
@@ -440,7 +440,7 @@
 						<div class="tsd-signature tsd-kind-icon">Box<wbr>Rec<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> =&nbsp;null</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L13">boxrec-pages/champions/boxrec.page.champions.ts:13</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L13">boxrec-pages/champions/boxrec.page.champions.ts:13</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -450,7 +450,7 @@
 						<div class="tsd-signature tsd-kind-icon">IBF<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> =&nbsp;null</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L17">boxrec-pages/champions/boxrec.page.champions.ts:17</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L17">boxrec-pages/champions/boxrec.page.champions.ts:17</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -460,7 +460,7 @@
 						<div class="tsd-signature tsd-kind-icon">IBO<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> =&nbsp;null</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L15">boxrec-pages/champions/boxrec.page.champions.ts:15</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L15">boxrec-pages/champions/boxrec.page.champions.ts:15</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -470,7 +470,7 @@
 						<div class="tsd-signature tsd-kind-icon">WBA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> =&nbsp;null</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L18">boxrec-pages/champions/boxrec.page.champions.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L18">boxrec-pages/champions/boxrec.page.champions.ts:18</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -480,7 +480,7 @@
 						<div class="tsd-signature tsd-kind-icon">WBC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> =&nbsp;null</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L14">boxrec-pages/champions/boxrec.page.champions.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L14">boxrec-pages/champions/boxrec.page.champions.ts:14</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -490,7 +490,7 @@
 						<div class="tsd-signature tsd-kind-icon">WBO<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> =&nbsp;null</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L16">boxrec-pages/champions/boxrec.page.champions.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L16">boxrec-pages/champions/boxrec.page.champions.ts:16</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -501,7 +501,7 @@
 					<div class="tsd-signature tsd-kind-icon">weight<wbr>Divisions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L21">boxrec-pages/champions/boxrec.page.champions.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L21">boxrec-pages/champions/boxrec.page.champions.ts:21</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal tsd-is-not-exported">
@@ -510,7 +510,7 @@
 						<div class="tsd-signature tsd-kind-icon">bantamweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L34">boxrec-pages/champions/boxrec.page.champions.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L34">boxrec-pages/champions/boxrec.page.champions.ts:34</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -520,7 +520,7 @@
 						<div class="tsd-signature tsd-kind-icon">cruiserweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L23">boxrec-pages/champions/boxrec.page.champions.ts:23</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L23">boxrec-pages/champions/boxrec.page.champions.ts:23</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -530,7 +530,7 @@
 						<div class="tsd-signature tsd-kind-icon">feather<wbr>Weight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L32">boxrec-pages/champions/boxrec.page.champions.ts:32</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L32">boxrec-pages/champions/boxrec.page.champions.ts:32</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -540,7 +540,7 @@
 						<div class="tsd-signature tsd-kind-icon">flyweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L36">boxrec-pages/champions/boxrec.page.champions.ts:36</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L36">boxrec-pages/champions/boxrec.page.champions.ts:36</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -550,7 +550,7 @@
 						<div class="tsd-signature tsd-kind-icon">heavyweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L22">boxrec-pages/champions/boxrec.page.champions.ts:22</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L22">boxrec-pages/champions/boxrec.page.champions.ts:22</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -560,7 +560,7 @@
 						<div class="tsd-signature tsd-kind-icon">light<wbr>Flyweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L37">boxrec-pages/champions/boxrec.page.champions.ts:37</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L37">boxrec-pages/champions/boxrec.page.champions.ts:37</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -570,7 +570,7 @@
 						<div class="tsd-signature tsd-kind-icon">light<wbr>Heavyweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L24">boxrec-pages/champions/boxrec.page.champions.ts:24</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L24">boxrec-pages/champions/boxrec.page.champions.ts:24</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -580,7 +580,7 @@
 						<div class="tsd-signature tsd-kind-icon">lightweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L30">boxrec-pages/champions/boxrec.page.champions.ts:30</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L30">boxrec-pages/champions/boxrec.page.champions.ts:30</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -590,7 +590,7 @@
 						<div class="tsd-signature tsd-kind-icon">middleweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L26">boxrec-pages/champions/boxrec.page.champions.ts:26</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L26">boxrec-pages/champions/boxrec.page.champions.ts:26</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -600,7 +600,7 @@
 						<div class="tsd-signature tsd-kind-icon">minimumweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L38">boxrec-pages/champions/boxrec.page.champions.ts:38</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L38">boxrec-pages/champions/boxrec.page.champions.ts:38</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -610,7 +610,7 @@
 						<div class="tsd-signature tsd-kind-icon">super<wbr>Bantamweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L33">boxrec-pages/champions/boxrec.page.champions.ts:33</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L33">boxrec-pages/champions/boxrec.page.champions.ts:33</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -620,7 +620,7 @@
 						<div class="tsd-signature tsd-kind-icon">super<wbr>Featherweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L31">boxrec-pages/champions/boxrec.page.champions.ts:31</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L31">boxrec-pages/champions/boxrec.page.champions.ts:31</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -630,7 +630,7 @@
 						<div class="tsd-signature tsd-kind-icon">super<wbr>Flyweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L35">boxrec-pages/champions/boxrec.page.champions.ts:35</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L35">boxrec-pages/champions/boxrec.page.champions.ts:35</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -640,7 +640,7 @@
 						<div class="tsd-signature tsd-kind-icon">super<wbr>Lightweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L29">boxrec-pages/champions/boxrec.page.champions.ts:29</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L29">boxrec-pages/champions/boxrec.page.champions.ts:29</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -650,7 +650,7 @@
 						<div class="tsd-signature tsd-kind-icon">super<wbr>Middleweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L25">boxrec-pages/champions/boxrec.page.champions.ts:25</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L25">boxrec-pages/champions/boxrec.page.champions.ts:25</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -660,7 +660,7 @@
 						<div class="tsd-signature tsd-kind-icon">super<wbr>Welterweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L27">boxrec-pages/champions/boxrec.page.champions.ts:27</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L27">boxrec-pages/champions/boxrec.page.champions.ts:27</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -670,7 +670,7 @@
 						<div class="tsd-signature tsd-kind-icon">welterweight<span class="tsd-signature-symbol">:</span> <a href="interfaces/boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a><span class="tsd-signature-symbol"> =&nbsp;beltOrganizations</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.page.champions.ts#L28">boxrec-pages/champions/boxrec.page.champions.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.page.champions.ts#L28">boxrec-pages/champions/boxrec.page.champions.ts:28</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/docs/interfaces/boutpageboutoutcome.html
+++ b/docs/interfaces/boutpageboutoutcome.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">boxer<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L19">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L19">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boutpageoutcome.html">BoutPageOutcome</a>.<a href="boutpageoutcome.html#outcome">outcome</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L14">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L14">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boutpageoutcome.html">BoutPageOutcome</a>.<a href="boutpageoutcome.html#outcomebywayof">outcomeByWayOf</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L15">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L15">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boutpagelast6.html
+++ b/docs/interfaces/boutpagelast6.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L8">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L8">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L9">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L9">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L10">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L10">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boutpageoutcome.html">BoutPageOutcome</a>.<a href="boutpageoutcome.html#outcome">outcome</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L14">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L14">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boutpageoutcome.html">BoutPageOutcome</a>.<a href="boutpageoutcome.html#outcomebywayof">outcomeByWayOf</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L15">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L15">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boutpageoutcome.html
+++ b/docs/interfaces/boutpageoutcome.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">outcome<span class="tsd-signature-symbol">:</span> <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L14">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L14">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">outcome<wbr>ByWay<wbr>Of<span class="tsd-signature-symbol">:</span> <a href="../enums/boxingboutoutcome.html" class="tsd-signature-type">BoxingBoutOutcome</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L15">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L15">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecbasic.html
+++ b/docs/interfaces/boxrecbasic.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecbelts.html
+++ b/docs/interfaces/boxrecbelts.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Box<wbr>Rec<span class="tsd-signature-symbol">:</span> <a href="boxrecchampion.html" class="tsd-signature-type">BoxrecChampion</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L34">boxrec-pages/champions/boxrec.champions.constants.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L34">boxrec-pages/champions/boxrec.champions.constants.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">IBF<span class="tsd-signature-symbol">:</span> <a href="boxrecchampion.html" class="tsd-signature-type">BoxrecChampion</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L35">boxrec-pages/champions/boxrec.champions.constants.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L35">boxrec-pages/champions/boxrec.champions.constants.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">IBO<span class="tsd-signature-symbol">:</span> <a href="boxrecchampion.html" class="tsd-signature-type">BoxrecChampion</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L36">boxrec-pages/champions/boxrec.champions.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L36">boxrec-pages/champions/boxrec.champions.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">WBA<span class="tsd-signature-symbol">:</span> <a href="boxrecchampion.html" class="tsd-signature-type">BoxrecChampion</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L37">boxrec-pages/champions/boxrec.champions.constants.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L37">boxrec-pages/champions/boxrec.champions.constants.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">WBC<span class="tsd-signature-symbol">:</span> <a href="boxrecchampion.html" class="tsd-signature-type">BoxrecChampion</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L38">boxrec-pages/champions/boxrec.champions.constants.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L38">boxrec-pages/champions/boxrec.champions.constants.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">WBO<span class="tsd-signature-symbol">:</span> <a href="boxrecchampion.html" class="tsd-signature-type">BoxrecChampion</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L39">boxrec-pages/champions/boxrec.champions.constants.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L39">boxrec-pages/champions/boxrec.champions.constants.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecbout.html
+++ b/docs/interfaces/boxrecbout.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L57">boxrec-pages/boxrec.constants.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L57">boxrec-pages/boxrec.constants.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#firstboxerweight">firstBoxerWeight</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L41">boxrec-pages/boxrec.constants.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L41">boxrec-pages/boxrec.constants.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#judges">judges</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L42">boxrec-pages/boxrec.constants.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L42">boxrec-pages/boxrec.constants.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#links">links</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L58">boxrec-pages/boxrec.constants.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L58">boxrec-pages/boxrec.constants.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <a href="boxrecprofileboutlocation.html" class="tsd-signature-type">BoxrecProfileBoutLocation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L59">boxrec-pages/boxrec.constants.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L59">boxrec-pages/boxrec.constants.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#metadata">metadata</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L44">boxrec-pages/boxrec.constants.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L44">boxrec-pages/boxrec.constants.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#numberofrounds">numberOfRounds</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L45">boxrec-pages/boxrec.constants.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L45">boxrec-pages/boxrec.constants.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#rating">rating</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L46">boxrec-pages/boxrec.constants.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L46">boxrec-pages/boxrec.constants.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#referee">referee</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L47">boxrec-pages/boxrec.constants.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L47">boxrec-pages/boxrec.constants.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#result">result</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L48">boxrec-pages/boxrec.constants.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L48">boxrec-pages/boxrec.constants.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#secondboxer">secondBoxer</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L49">boxrec-pages/boxrec.constants.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L49">boxrec-pages/boxrec.constants.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#secondboxerlast6">secondBoxerLast6</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L50">boxrec-pages/boxrec.constants.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L50">boxrec-pages/boxrec.constants.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -243,7 +243,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#secondboxerrecord">secondBoxerRecord</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L51">boxrec-pages/boxrec.constants.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L51">boxrec-pages/boxrec.constants.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -254,7 +254,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#secondboxerweight">secondBoxerWeight</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L52">boxrec-pages/boxrec.constants.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L52">boxrec-pages/boxrec.constants.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -265,7 +265,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecboutbasic.html">BoxrecBoutBasic</a>.<a href="boxrecboutbasic.html#titles">titles</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L53">boxrec-pages/boxrec.constants.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L53">boxrec-pages/boxrec.constants.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecboutbasic.html
+++ b/docs/interfaces/boxrecboutbasic.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Weight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L41">boxrec-pages/boxrec.constants.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L41">boxrec-pages/boxrec.constants.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">judges<span class="tsd-signature-symbol">:</span> <a href="boxrecjudge.html" class="tsd-signature-type">BoxrecJudge</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L42">boxrec-pages/boxrec.constants.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L42">boxrec-pages/boxrec.constants.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">links<span class="tsd-signature-symbol">:</span> <a href="boxrecgenerallinks.html" class="tsd-signature-type">BoxrecGeneralLinks</a><span class="tsd-signature-symbol"> | </span><a href="boxreceventlinks.html" class="tsd-signature-type">BoxrecEventLinks</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L43">boxrec-pages/boxrec.constants.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L43">boxrec-pages/boxrec.constants.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">metadata<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L44">boxrec-pages/boxrec.constants.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L44">boxrec-pages/boxrec.constants.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfRounds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L45">boxrec-pages/boxrec.constants.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L45">boxrec-pages/boxrec.constants.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">rating<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L46">boxrec-pages/boxrec.constants.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L46">boxrec-pages/boxrec.constants.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">referee<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L47">boxrec-pages/boxrec.constants.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L47">boxrec-pages/boxrec.constants.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">result<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">, </span><a href="../enums/boxingboutoutcome.html" class="tsd-signature-type">BoxingBoutOutcome</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">, </span><a href="../enums/boxingboutoutcome.html" class="tsd-signature-type">BoxingBoutOutcome</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L48">boxrec-pages/boxrec.constants.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L48">boxrec-pages/boxrec.constants.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L49">boxrec-pages/boxrec.constants.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L49">boxrec-pages/boxrec.constants.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Last6<span class="tsd-signature-symbol">:</span> <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L50">boxrec-pages/boxrec.constants.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L50">boxrec-pages/boxrec.constants.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Record<span class="tsd-signature-symbol">:</span> <a href="record.html" class="tsd-signature-type">Record</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L51">boxrec-pages/boxrec.constants.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L51">boxrec-pages/boxrec.constants.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Weight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L52">boxrec-pages/boxrec.constants.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L52">boxrec-pages/boxrec.constants.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">titles<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L53">boxrec-pages/boxrec.constants.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L53">boxrec-pages/boxrec.constants.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecboutlocation.html
+++ b/docs/interfaces/boxrecboutlocation.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <a href="boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L13">boxrec-pages/boxrec.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L13">boxrec-pages/boxrec.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">venue<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L14">boxrec-pages/boxrec.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L14">boxrec-pages/boxrec.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecboxerwatch.html
+++ b/docs/interfaces/boxrecboxerwatch.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">alias<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.watch.constants.ts#L5">boxrec-pages/watch/boxrec.watch.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.watch.constants.ts#L5">boxrec-pages/watch/boxrec.watch.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.watch.constants.ts#L6">boxrec-pages/watch/boxrec.watch.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.watch.constants.ts#L6">boxrec-pages/watch/boxrec.watch.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">last6<span class="tsd-signature-symbol">:</span> <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.watch.constants.ts#L7">boxrec-pages/watch/boxrec.watch.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.watch.constants.ts#L7">boxrec-pages/watch/boxrec.watch.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.watch.constants.ts#L8">boxrec-pages/watch/boxrec.watch.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.watch.constants.ts#L8">boxrec-pages/watch/boxrec.watch.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">schedule<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.watch.constants.ts#L9">boxrec-pages/watch/boxrec.watch.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.watch.constants.ts#L9">boxrec-pages/watch/boxrec.watch.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecchampion.html
+++ b/docs/interfaces/boxrecchampion.html
@@ -101,7 +101,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#id">id</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L30">boxrec-pages/champions/boxrec.champions.constants.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L30">boxrec-pages/champions/boxrec.champions.constants.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecchampionsbyweightdivision.html
+++ b/docs/interfaces/boxrecchampionsbyweightdivision.html
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">bantamweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L4">boxrec-pages/champions/boxrec.champions.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L4">boxrec-pages/champions/boxrec.champions.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">cruiserweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L5">boxrec-pages/champions/boxrec.champions.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L5">boxrec-pages/champions/boxrec.champions.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">feather<wbr>Weight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L6">boxrec-pages/champions/boxrec.champions.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L6">boxrec-pages/champions/boxrec.champions.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">flyweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L7">boxrec-pages/champions/boxrec.champions.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L7">boxrec-pages/champions/boxrec.champions.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">heavyweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L8">boxrec-pages/champions/boxrec.champions.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L8">boxrec-pages/champions/boxrec.champions.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">light<wbr>Flyweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L9">boxrec-pages/champions/boxrec.champions.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L9">boxrec-pages/champions/boxrec.champions.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">light<wbr>Heavyweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L10">boxrec-pages/champions/boxrec.champions.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L10">boxrec-pages/champions/boxrec.champions.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">lightweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L11">boxrec-pages/champions/boxrec.champions.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L11">boxrec-pages/champions/boxrec.champions.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">middleweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L12">boxrec-pages/champions/boxrec.champions.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L12">boxrec-pages/champions/boxrec.champions.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">minimumweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L13">boxrec-pages/champions/boxrec.champions.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L13">boxrec-pages/champions/boxrec.champions.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Bantamweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L14">boxrec-pages/champions/boxrec.champions.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L14">boxrec-pages/champions/boxrec.champions.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Featherweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L15">boxrec-pages/champions/boxrec.champions.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L15">boxrec-pages/champions/boxrec.champions.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Flyweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L16">boxrec-pages/champions/boxrec.champions.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L16">boxrec-pages/champions/boxrec.champions.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Lightweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L17">boxrec-pages/champions/boxrec.champions.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L17">boxrec-pages/champions/boxrec.champions.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Middleweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L18">boxrec-pages/champions/boxrec.champions.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L18">boxrec-pages/champions/boxrec.champions.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -259,7 +259,7 @@
 					<div class="tsd-signature tsd-kind-icon">super<wbr>Welterweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L19">boxrec-pages/champions/boxrec.champions.constants.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L19">boxrec-pages/champions/boxrec.champions.constants.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -269,7 +269,7 @@
 					<div class="tsd-signature tsd-kind-icon">welterweight<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L20">boxrec-pages/champions/boxrec.champions.constants.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L20">boxrec-pages/champions/boxrec.champions.constants.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecchampionsoutput.html
+++ b/docs/interfaces/boxrecchampionsoutput.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">boxing<wbr>Organizations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L24">boxrec-pages/champions/boxrec.champions.constants.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L24">boxrec-pages/champions/boxrec.champions.constants.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">by<wbr>Weight<wbr>Division<span class="tsd-signature-symbol">:</span> <a href="boxrecchampionsbyweightdivision.html" class="tsd-signature-type">BoxrecChampionsByWeightDivision</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L25">boxrec-pages/champions/boxrec.champions.constants.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L25">boxrec-pages/champions/boxrec.champions.constants.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">champions<span class="tsd-signature-symbol">:</span> <a href="boxrecunformattedchampions.html" class="tsd-signature-type">BoxrecUnformattedChampions</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L26">boxrec-pages/champions/boxrec.champions.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L26">boxrec-pages/champions/boxrec.champions.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecdateoutput.html
+++ b/docs/interfaces/boxrecdateoutput.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">events<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecdateevent.html" class="tsd-signature-type">BoxrecDateEvent</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/date/boxrec.page.date.constants.ts#L4">boxrec-pages/date/boxrec.page.date.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/date/boxrec.page.date.constants.ts#L4">boxrec-pages/date/boxrec.page.date.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxreceventboutoutput.html
+++ b/docs/interfaces/boxreceventboutoutput.html
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">bouts<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpageeventboutrow.html" class="tsd-signature-type">BoxrecPageEventBoutRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L23">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L23">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">commission<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L24">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L24">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L25">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L25">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L26">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L26">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">doctors<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L27">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L27">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L28">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L28">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Age<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L29">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L29">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L30">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L30">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>BoxerKOs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L31">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L31">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Last6<span class="tsd-signature-symbol">:</span> <a href="boutpagelast6.html" class="tsd-signature-type">BoutPageLast6</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L32">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L32">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Points<wbr>After<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L33">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L33">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Points<wbr>Before<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L34">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L34">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Ranking<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L35">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L35">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Reach<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L36">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L36">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Record<span class="tsd-signature-symbol">:</span> <a href="record.html" class="tsd-signature-type">Record</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L37">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L37">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -282,7 +282,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Boxer<wbr>Stance<span class="tsd-signature-symbol">:</span> <a href="../globals.html#stance" class="tsd-signature-type">Stance</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L38">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L38">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L39">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L39">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -302,7 +302,7 @@
 					<div class="tsd-signature tsd-kind-icon">inspector<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L40">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L40">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -312,7 +312,7 @@
 					<div class="tsd-signature tsd-kind-icon">judges<span class="tsd-signature-symbol">:</span> <a href="boxrecjudge.html" class="tsd-signature-type">BoxrecJudge</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L41">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L41">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -322,7 +322,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <a href="boxrecboutlocation.html" class="tsd-signature-type">BoxrecBoutLocation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L42">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L42">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -332,7 +332,7 @@
 					<div class="tsd-signature tsd-kind-icon">matchmakers<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L43">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L43">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -342,7 +342,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfBouts<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L44">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L44">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -352,7 +352,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfRounds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L45">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L45">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -362,7 +362,7 @@
 					<div class="tsd-signature tsd-kind-icon">outcome<span class="tsd-signature-symbol">:</span> <a href="boutpageboutoutcome.html" class="tsd-signature-type">BoutPageBoutOutcome</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L46">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L46">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -372,7 +372,7 @@
 					<div class="tsd-signature tsd-kind-icon">promoters<span class="tsd-signature-symbol">:</span> <a href="boxrecpromoter.html" class="tsd-signature-type">BoxrecPromoter</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L47">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L47">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -382,7 +382,7 @@
 					<div class="tsd-signature tsd-kind-icon">rating<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L48">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L48">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -392,7 +392,7 @@
 					<div class="tsd-signature tsd-kind-icon">referee<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L49">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L49">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -402,7 +402,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L50">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L50">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -412,7 +412,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Age<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L51">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L51">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -422,7 +422,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L52">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L52">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -432,7 +432,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>BoxerKOs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L53">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L53">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -442,7 +442,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Last6<span class="tsd-signature-symbol">:</span> <a href="boutpagelast6.html" class="tsd-signature-type">BoutPageLast6</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L54">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L54">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -452,7 +452,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Points<wbr>After<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L55">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L55">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -462,7 +462,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Points<wbr>Before<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L56">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L56">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -472,7 +472,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Ranking<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L57">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L57">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -482,7 +482,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Reach<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L58">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L58">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -492,7 +492,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Record<span class="tsd-signature-symbol">:</span> <a href="record.html" class="tsd-signature-type">Record</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L59">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L59">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -502,7 +502,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Boxer<wbr>Stance<span class="tsd-signature-symbol">:</span> <a href="../globals.html#stance" class="tsd-signature-type">Stance</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L60">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L60">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -512,7 +512,7 @@
 					<div class="tsd-signature tsd-kind-icon">television<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L61">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L61">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -522,7 +522,7 @@
 					<div class="tsd-signature tsd-kind-icon">titles<span class="tsd-signature-symbol">:</span> <a href="boxrectitles.html" class="tsd-signature-type">BoxrecTitles</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L62">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/bout/boxrec.event.bout.constants.ts#L62">boxrec-pages/event/bout/boxrec.event.bout.constants.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxreceventlinks.html
+++ b/docs/interfaces/boxreceventlinks.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">bio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L21">boxrec-pages/event/boxrec.event.constants.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L21">boxrec-pages/event/boxrec.event.constants.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">bout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L22">boxrec-pages/event/boxrec.event.constants.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L22">boxrec-pages/event/boxrec.event.constants.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">other<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L23">boxrec-pages/event/boxrec.event.constants.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L23">boxrec-pages/event/boxrec.event.constants.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxreceventoutput.html
+++ b/docs/interfaces/boxreceventoutput.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">bouts<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpageeventboutrow.html" class="tsd-signature-type">BoxrecPageEventBoutRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L27">boxrec-pages/event/boxrec.event.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L27">boxrec-pages/event/boxrec.event.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">commission<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L28">boxrec-pages/event/boxrec.event.constants.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L28">boxrec-pages/event/boxrec.event.constants.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L29">boxrec-pages/event/boxrec.event.constants.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L29">boxrec-pages/event/boxrec.event.constants.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">doctors<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L30">boxrec-pages/event/boxrec.event.constants.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L30">boxrec-pages/event/boxrec.event.constants.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L31">boxrec-pages/event/boxrec.event.constants.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L31">boxrec-pages/event/boxrec.event.constants.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">inspector<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L32">boxrec-pages/event/boxrec.event.constants.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L32">boxrec-pages/event/boxrec.event.constants.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <a href="boxrecboutlocation.html" class="tsd-signature-type">BoxrecBoutLocation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L33">boxrec-pages/event/boxrec.event.constants.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L33">boxrec-pages/event/boxrec.event.constants.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">matchmakers<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L34">boxrec-pages/event/boxrec.event.constants.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L34">boxrec-pages/event/boxrec.event.constants.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfBouts<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L35">boxrec-pages/event/boxrec.event.constants.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L35">boxrec-pages/event/boxrec.event.constants.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">promoters<span class="tsd-signature-symbol">:</span> <a href="boxrecpromoter.html" class="tsd-signature-type">BoxrecPromoter</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L36">boxrec-pages/event/boxrec.event.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L36">boxrec-pages/event/boxrec.event.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">television<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L37">boxrec-pages/event/boxrec.event.constants.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L37">boxrec-pages/event/boxrec.event.constants.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecgenerallinks.html
+++ b/docs/interfaces/boxrecgenerallinks.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">bio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common.constants.ts#L11">boxrec-common-tables/boxrec-common.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common.constants.ts#L11">boxrec-common-tables/boxrec-common.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">bout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common.constants.ts#L12">boxrec-common-tables/boxrec-common.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common.constants.ts#L12">boxrec-common-tables/boxrec-common.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">event<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common.constants.ts#L13">boxrec-common-tables/boxrec-common.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common.constants.ts#L13">boxrec-common-tables/boxrec-common.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">other<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common.constants.ts#L14">boxrec-common-tables/boxrec-common.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common.constants.ts#L14">boxrec-common-tables/boxrec-common.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecjudge.html
+++ b/docs/interfaces/boxrecjudge.html
@@ -101,7 +101,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#id">id</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">scorecard<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L31">boxrec-pages/boxrec.constants.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L31">boxrec-pages/boxrec.constants.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxreclocation.html
+++ b/docs/interfaces/boxreclocation.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">country<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L6">boxrec-pages/boxrec.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L6">boxrec-pages/boxrec.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L7">boxrec-pages/boxrec.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L7">boxrec-pages/boxrec.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">region<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L8">boxrec-pages/boxrec.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L8">boxrec-pages/boxrec.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">town<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L9">boxrec-pages/boxrec.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L9">boxrec-pages/boxrec.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxreclocationeventparams.html
+++ b/docs/interfaces/boxreclocationeventparams.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">country<span class="tsd-signature-symbol">:</span> <a href="../enums/country.html" class="tsd-signature-type">Country</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L4">boxrec-pages/location/event/boxrec.location.event.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L4">boxrec-pages/location/event/boxrec.location.event.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L5">boxrec-pages/location/event/boxrec.location.event.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L5">boxrec-pages/location/event/boxrec.location.event.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">region<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L6">boxrec-pages/location/event/boxrec.location.event.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L6">boxrec-pages/location/event/boxrec.location.event.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">town<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L7">boxrec-pages/location/event/boxrec.location.event.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L7">boxrec-pages/location/event/boxrec.location.event.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">venue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L8">boxrec-pages/location/event/boxrec.location.event.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L8">boxrec-pages/location/event/boxrec.location.event.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">year<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L9">boxrec-pages/location/event/boxrec.location.event.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/event/boxrec.location.event.constants.ts#L9">boxrec-pages/location/event/boxrec.location.event.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxreclocationspeopleparams.html
+++ b/docs/interfaces/boxreclocationspeopleparams.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">country<span class="tsd-signature-symbol">:</span> <a href="../enums/country.html" class="tsd-signature-type">Country</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L5">boxrec-pages/location/people/boxrec.location.people.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L5">boxrec-pages/location/people/boxrec.location.people.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <a href="../enums/weightdivisioncapitalized.html" class="tsd-signature-type">WeightDivisionCapitalized</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L6">boxrec-pages/location/people/boxrec.location.people.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L6">boxrec-pages/location/people/boxrec.location.people.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">l_<wbr>go<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L7">boxrec-pages/location/people/boxrec.location.people.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L7">boxrec-pages/location/people/boxrec.location.people.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">region<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L8">boxrec-pages/location/people/boxrec.location.people.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L8">boxrec-pages/location/people/boxrec.location.people.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">role<span class="tsd-signature-symbol">:</span> <a href="../enums/boxrecrole.html" class="tsd-signature-type">BoxrecRole</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L9">boxrec-pages/location/people/boxrec.location.people.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L9">boxrec-pages/location/people/boxrec.location.people.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">town<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L10">boxrec-pages/location/people/boxrec.location.people.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L10">boxrec-pages/location/people/boxrec.location.people.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxreclocationspeopleparamstransformed.html
+++ b/docs/interfaces/boxreclocationspeopleparamstransformed.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">l[country]<span class="tsd-signature-symbol">:</span> <a href="../enums/country.html" class="tsd-signature-type">Country</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L14">boxrec-pages/location/people/boxrec.location.people.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L14">boxrec-pages/location/people/boxrec.location.people.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">l[division]<span class="tsd-signature-symbol">:</span> <a href="../enums/weightdivisioncapitalized.html" class="tsd-signature-type">WeightDivisionCapitalized</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L15">boxrec-pages/location/people/boxrec.location.people.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L15">boxrec-pages/location/people/boxrec.location.people.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">l[region]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L16">boxrec-pages/location/people/boxrec.location.people.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L16">boxrec-pages/location/people/boxrec.location.people.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">l[role]<span class="tsd-signature-symbol">:</span> <a href="../enums/boxrecrole.html" class="tsd-signature-type">BoxrecRole</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L17">boxrec-pages/location/people/boxrec.location.people.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L17">boxrec-pages/location/people/boxrec.location.people.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">l[town]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L18">boxrec-pages/location/people/boxrec.location.people.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L18">boxrec-pages/location/people/boxrec.location.people.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">l_<wbr>go<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L19">boxrec-pages/location/people/boxrec.location.people.constants.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L19">boxrec-pages/location/people/boxrec.location.people.constants.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L20">boxrec-pages/location/people/boxrec.location.people.constants.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/location/people/boxrec.location.people.constants.ts#L20">boxrec-pages/location/people/boxrec.location.people.constants.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofile.html
+++ b/docs/interfaces/boxrecprofile.html
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">KOs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L5">boxrec-pages/profile/boxrec.profile.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L5">boxrec-pages/profile/boxrec.profile.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">alias<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L6">boxrec-pages/profile/boxrec.profile.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L6">boxrec-pages/profile/boxrec.profile.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">birth<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L7">boxrec-pages/profile/boxrec.profile.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L7">boxrec-pages/profile/boxrec.profile.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">birth<wbr>Place<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L8">boxrec-pages/profile/boxrec.profile.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L8">boxrec-pages/profile/boxrec.profile.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">born<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L9">boxrec-pages/profile/boxrec.profile.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L9">boxrec-pages/profile/boxrec.profile.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">bouts<span class="tsd-signature-symbol">:</span> <a href="boxrecbout.html" class="tsd-signature-type">BoxrecBout</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L10">boxrec-pages/profile/boxrec.profile.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L10">boxrec-pages/profile/boxrec.profile.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">debut<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L11">boxrec-pages/profile/boxrec.profile.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L11">boxrec-pages/profile/boxrec.profile.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L12">boxrec-pages/profile/boxrec.profile.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L12">boxrec-pages/profile/boxrec.profile.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L13">boxrec-pages/profile/boxrec.profile.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L13">boxrec-pages/profile/boxrec.profile.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Bout<wbr>Scheduled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L14">boxrec-pages/profile/boxrec.profile.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L14">boxrec-pages/profile/boxrec.profile.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L15">boxrec-pages/profile/boxrec.profile.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L15">boxrec-pages/profile/boxrec.profile.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L16">boxrec-pages/profile/boxrec.profile.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L16">boxrec-pages/profile/boxrec.profile.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">nationality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L17">boxrec-pages/profile/boxrec.profile.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L17">boxrec-pages/profile/boxrec.profile.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfBouts<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L18">boxrec-pages/profile/boxrec.profile.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L18">boxrec-pages/profile/boxrec.profile.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">other<wbr>Info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L19">boxrec-pages/profile/boxrec.profile.constants.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L19">boxrec-pages/profile/boxrec.profile.constants.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">ranking<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L20">boxrec-pages/profile/boxrec.profile.constants.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L20">boxrec-pages/profile/boxrec.profile.constants.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">rating<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L21">boxrec-pages/profile/boxrec.profile.constants.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L21">boxrec-pages/profile/boxrec.profile.constants.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">reach<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L22">boxrec-pages/profile/boxrec.profile.constants.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L22">boxrec-pages/profile/boxrec.profile.constants.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">residence<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L23">boxrec-pages/profile/boxrec.profile.constants.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L23">boxrec-pages/profile/boxrec.profile.constants.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">role<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L24">boxrec-pages/profile/boxrec.profile.constants.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L24">boxrec-pages/profile/boxrec.profile.constants.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">rounds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L25">boxrec-pages/profile/boxrec.profile.constants.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L25">boxrec-pages/profile/boxrec.profile.constants.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -328,7 +328,7 @@
 					<div class="tsd-signature tsd-kind-icon">stance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L26">boxrec-pages/profile/boxrec.profile.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L26">boxrec-pages/profile/boxrec.profile.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -338,7 +338,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L27">boxrec-pages/profile/boxrec.profile.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L27">boxrec-pages/profile/boxrec.profile.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -348,7 +348,7 @@
 					<div class="tsd-signature tsd-kind-icon">suspended<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L28">boxrec-pages/profile/boxrec.profile.constants.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L28">boxrec-pages/profile/boxrec.profile.constants.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -358,7 +358,7 @@
 					<div class="tsd-signature tsd-kind-icon">titles<wbr>Held<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L29">boxrec-pages/profile/boxrec.profile.constants.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L29">boxrec-pages/profile/boxrec.profile.constants.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -368,7 +368,7 @@
 					<div class="tsd-signature tsd-kind-icon">vadacbp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L30">boxrec-pages/profile/boxrec.profile.constants.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L30">boxrec-pages/profile/boxrec.profile.constants.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofileboutlocation.html
+++ b/docs/interfaces/boxrecprofileboutlocation.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">town<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L60">boxrec-pages/profile/boxrec.profile.constants.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L60">boxrec-pages/profile/boxrec.profile.constants.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">venue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L61">boxrec-pages/profile/boxrec.profile.constants.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L61">boxrec-pages/profile/boxrec.profile.constants.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofileboxeroutput.html
+++ b/docs/interfaces/boxrecprofileboxeroutput.html
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">KOs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L22">boxrec-pages/profile/boxrec.page.profile.constants.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L22">boxrec-pages/profile/boxrec.page.profile.constants.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">alias<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L23">boxrec-pages/profile/boxrec.page.profile.constants.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L23">boxrec-pages/profile/boxrec.page.profile.constants.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthname">birthName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthplace">birthPlace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">born<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L24">boxrec-pages/profile/boxrec.page.profile.constants.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L24">boxrec-pages/profile/boxrec.page.profile.constants.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">bouts<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpageprofileboxerboutrow.html" class="tsd-signature-type">BoxrecPageProfileBoxerBoutRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L25">boxrec-pages/profile/boxrec.page.profile.constants.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L25">boxrec-pages/profile/boxrec.page.profile.constants.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">debut<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L26">boxrec-pages/profile/boxrec.page.profile.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L26">boxrec-pages/profile/boxrec.page.profile.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L27">boxrec-pages/profile/boxrec.page.profile.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L27">boxrec-pages/profile/boxrec.page.profile.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#globalid">globalId</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Bout<wbr>Scheduled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L28">boxrec-pages/profile/boxrec.page.profile.constants.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L28">boxrec-pages/profile/boxrec.page.profile.constants.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L29">boxrec-pages/profile/boxrec.page.profile.constants.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L29">boxrec-pages/profile/boxrec.page.profile.constants.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">nationality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L30">boxrec-pages/profile/boxrec.page.profile.constants.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L30">boxrec-pages/profile/boxrec.page.profile.constants.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfBouts<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L31">boxrec-pages/profile/boxrec.page.profile.constants.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L31">boxrec-pages/profile/boxrec.page.profile.constants.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -269,7 +269,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#otherinfo">otherInfo</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -280,7 +280,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#picture">picture</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -290,7 +290,7 @@
 					<div class="tsd-signature tsd-kind-icon">ranking<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L32">boxrec-pages/profile/boxrec.page.profile.constants.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L32">boxrec-pages/profile/boxrec.page.profile.constants.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -300,7 +300,7 @@
 					<div class="tsd-signature tsd-kind-icon">rating<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L33">boxrec-pages/profile/boxrec.page.profile.constants.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L33">boxrec-pages/profile/boxrec.page.profile.constants.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -310,7 +310,7 @@
 					<div class="tsd-signature tsd-kind-icon">reach<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L34">boxrec-pages/profile/boxrec.page.profile.constants.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L34">boxrec-pages/profile/boxrec.page.profile.constants.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -321,7 +321,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#residence">residence</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -332,7 +332,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#role">role</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -342,7 +342,7 @@
 					<div class="tsd-signature tsd-kind-icon">rounds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L35">boxrec-pages/profile/boxrec.page.profile.constants.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L35">boxrec-pages/profile/boxrec.page.profile.constants.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -352,7 +352,7 @@
 					<div class="tsd-signature tsd-kind-icon">stance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L36">boxrec-pages/profile/boxrec.page.profile.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L36">boxrec-pages/profile/boxrec.page.profile.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -363,7 +363,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#status">status</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -373,7 +373,7 @@
 					<div class="tsd-signature tsd-kind-icon">suspended<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L37">boxrec-pages/profile/boxrec.page.profile.constants.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L37">boxrec-pages/profile/boxrec.page.profile.constants.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -383,7 +383,7 @@
 					<div class="tsd-signature tsd-kind-icon">titles<wbr>Held<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L38">boxrec-pages/profile/boxrec.page.profile.constants.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L38">boxrec-pages/profile/boxrec.page.profile.constants.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -393,7 +393,7 @@
 					<div class="tsd-signature tsd-kind-icon">vadacbp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L39">boxrec-pages/profile/boxrec.page.profile.constants.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L39">boxrec-pages/profile/boxrec.page.profile.constants.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofileeventlinks.html
+++ b/docs/interfaces/boxrecprofileeventlinks.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">event<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L65">boxrec-pages/profile/boxrec.profile.constants.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L65">boxrec-pages/profile/boxrec.profile.constants.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofileeventsoutput.html
+++ b/docs/interfaces/boxrecprofileeventsoutput.html
@@ -113,7 +113,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthname">birthName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthplace">birthPlace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">events<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpageprofileeventrow.html" class="tsd-signature-type">BoxrecPageProfileEventRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L55">boxrec-pages/profile/boxrec.page.profile.constants.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L55">boxrec-pages/profile/boxrec.page.profile.constants.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#globalid">globalId</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#otherinfo">otherInfo</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#picture">picture</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#residence">residence</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#role">role</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#status">status</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofilemanageroutput.html
+++ b/docs/interfaces/boxrecprofilemanageroutput.html
@@ -108,7 +108,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthname">birthName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthplace">birthPlace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">boxers<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpageprofilemanagerboxerrow.html" class="tsd-signature-type">BoxrecPageProfileManagerBoxerRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L43">boxrec-pages/profile/boxrec.page.profile.constants.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L43">boxrec-pages/profile/boxrec.page.profile.constants.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#globalid">globalId</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#otherinfo">otherInfo</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#picture">picture</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#residence">residence</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#role">role</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#status">status</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofileotheroutput.html
+++ b/docs/interfaces/boxrecprofileotheroutput.html
@@ -108,7 +108,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthname">birthName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthplace">birthPlace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">bouts<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpageprofileothercommonboutrow.html" class="tsd-signature-type">BoxrecPageProfileOtherCommonBoutRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L47">boxrec-pages/profile/boxrec.page.profile.constants.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L47">boxrec-pages/profile/boxrec.page.profile.constants.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#globalid">globalId</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#otherinfo">otherInfo</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#picture">picture</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#residence">residence</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#role">role</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#status">status</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofileoutput.html
+++ b/docs/interfaces/boxrecprofileoutput.html
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">birth<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">birth<wbr>Place<span class="tsd-signature-symbol">:</span> <a href="boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">other<wbr>Info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">residence<span class="tsd-signature-symbol">:</span> <a href="boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">role<span class="tsd-signature-symbol">:</span> <a href="boxrecprofilerole.html" class="tsd-signature-type">BoxrecProfileRole</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofilepromoteroutput.html
+++ b/docs/interfaces/boxrecprofilepromoteroutput.html
@@ -109,7 +109,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthname">birthName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L10">boxrec-pages/profile/boxrec.page.profile.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#birthplace">birthPlace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L11">boxrec-pages/profile/boxrec.page.profile.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">company<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L51">boxrec-pages/profile/boxrec.page.profile.constants.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L51">boxrec-pages/profile/boxrec.page.profile.constants.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileeventsoutput.html">BoxrecProfileEventsOutput</a>.<a href="boxrecprofileeventsoutput.html#events">events</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L55">boxrec-pages/profile/boxrec.page.profile.constants.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L55">boxrec-pages/profile/boxrec.page.profile.constants.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#globalid">globalId</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L12">boxrec-pages/profile/boxrec.page.profile.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L13">boxrec-pages/profile/boxrec.page.profile.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#otherinfo">otherInfo</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L14">boxrec-pages/profile/boxrec.page.profile.constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#picture">picture</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L15">boxrec-pages/profile/boxrec.page.profile.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#residence">residence</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L16">boxrec-pages/profile/boxrec.page.profile.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#role">role</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L17">boxrec-pages/profile/boxrec.page.profile.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecprofileoutput.html">BoxrecProfileOutput</a>.<a href="boxrecprofileoutput.html#status">status</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.page.profile.constants.ts#L18">boxrec-pages/profile/boxrec.page.profile.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecprofilerole.html
+++ b/docs/interfaces/boxrecprofilerole.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L76">boxrec-pages/profile/boxrec.profile.constants.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L76">boxrec-pages/profile/boxrec.profile.constants.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <a href="../enums/boxrecrole.html" class="tsd-signature-type">BoxrecRole</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L77">boxrec-pages/profile/boxrec.profile.constants.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L77">boxrec-pages/profile/boxrec.profile.constants.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecpromoter.html
+++ b/docs/interfaces/boxrecpromoter.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">company<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/event/boxrec.event.constants.ts#L5">boxrec-pages/event/boxrec.event.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/event/boxrec.event.constants.ts#L5">boxrec-pages/event/boxrec.event.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#id">id</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecrating.html
+++ b/docs/interfaces/boxrecrating.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">age<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L15">boxrec-pages/ratings/boxrec.ratings.constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L15">boxrec-pages/ratings/boxrec.ratings.constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L16">boxrec-pages/ratings/boxrec.ratings.constants.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L16">boxrec-pages/ratings/boxrec.ratings.constants.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#id">id</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L26">boxrec-pages/boxrec.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">last6<span class="tsd-signature-symbol">:</span> <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L17">boxrec-pages/ratings/boxrec.ratings.constants.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L17">boxrec-pages/ratings/boxrec.ratings.constants.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">points<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L18">boxrec-pages/ratings/boxrec.ratings.constants.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L18">boxrec-pages/ratings/boxrec.ratings.constants.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">rating<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L19">boxrec-pages/ratings/boxrec.ratings.constants.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L19">boxrec-pages/ratings/boxrec.ratings.constants.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">record<span class="tsd-signature-symbol">:</span> <a href="record.html" class="tsd-signature-type">Record</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L20">boxrec-pages/ratings/boxrec.ratings.constants.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L20">boxrec-pages/ratings/boxrec.ratings.constants.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">residence<span class="tsd-signature-symbol">:</span> <a href="boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L21">boxrec-pages/ratings/boxrec.ratings.constants.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L21">boxrec-pages/ratings/boxrec.ratings.constants.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">stance<span class="tsd-signature-symbol">:</span> <a href="../globals.html#stance" class="tsd-signature-type">Stance</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L22">boxrec-pages/ratings/boxrec.ratings.constants.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L22">boxrec-pages/ratings/boxrec.ratings.constants.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecratingsoutput.html
+++ b/docs/interfaces/boxrecratingsoutput.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">boxers<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpageratingsrow.html" class="tsd-signature-type">BoxrecPageRatingsRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L26">boxrec-pages/ratings/boxrec.ratings.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L26">boxrec-pages/ratings/boxrec.ratings.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfPages<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L27">boxrec-pages/ratings/boxrec.ratings.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L27">boxrec-pages/ratings/boxrec.ratings.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecratingsparams.html
+++ b/docs/interfaces/boxrecratingsparams.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">country<span class="tsd-signature-symbol">:</span> <a href="../enums/country.html" class="tsd-signature-type">Country</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L7">boxrec-pages/ratings/boxrec.ratings.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L7">boxrec-pages/ratings/boxrec.ratings.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <a href="../enums/weightdivisioncapitalized.html" class="tsd-signature-type">WeightDivisionCapitalized</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L8">boxrec-pages/ratings/boxrec.ratings.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L8">boxrec-pages/ratings/boxrec.ratings.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">sex<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"M"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"F"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L9">boxrec-pages/ratings/boxrec.ratings.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L9">boxrec-pages/ratings/boxrec.ratings.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">stance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"O"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"S"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L10">boxrec-pages/ratings/boxrec.ratings.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L10">boxrec-pages/ratings/boxrec.ratings.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"a"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L11">boxrec-pages/ratings/boxrec.ratings.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/ratings/boxrec.ratings.constants.ts#L11">boxrec-pages/ratings/boxrec.ratings.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecresultsparams.html
+++ b/docs/interfaces/boxrecresultsparams.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">country<wbr>Code<span class="tsd-signature-symbol">:</span> <a href="../enums/country.html" class="tsd-signature-type">Country</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L4">boxrec-pages/results/boxrec.results.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L4">boxrec-pages/results/boxrec.results.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L5">boxrec-pages/results/boxrec.results.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L5">boxrec-pages/results/boxrec.results.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L6">boxrec-pages/results/boxrec.results.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L6">boxrec-pages/results/boxrec.results.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecresultsparamstransformed.html
+++ b/docs/interfaces/boxrecresultsparamstransformed.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">c[country<wbr>Code]<span class="tsd-signature-symbol">:</span> <a href="../enums/country.html" class="tsd-signature-type">Country</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L10">boxrec-pages/results/boxrec.results.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L10">boxrec-pages/results/boxrec.results.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">c[division]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L11">boxrec-pages/results/boxrec.results.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L11">boxrec-pages/results/boxrec.results.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L12">boxrec-pages/results/boxrec.results.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L12">boxrec-pages/results/boxrec.results.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecscheduleoutput.html
+++ b/docs/interfaces/boxrecscheduleoutput.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">events<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpageevent.html" class="tsd-signature-type">BoxrecPageEvent</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.constants.ts#L4">boxrec-pages/schedule/boxrec.page.schedule.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.constants.ts#L4">boxrec-pages/schedule/boxrec.page.schedule.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfPages<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.page.schedule.constants.ts#L5">boxrec-pages/schedule/boxrec.page.schedule.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.page.schedule.constants.ts#L5">boxrec-pages/schedule/boxrec.page.schedule.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecscheduleparams.html
+++ b/docs/interfaces/boxrecscheduleparams.html
@@ -102,7 +102,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecresultsparams.html">BoxrecResultsParams</a>.<a href="boxrecresultsparams.html#countrycode">countryCode</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L4">boxrec-pages/results/boxrec.results.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L4">boxrec-pages/results/boxrec.results.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecresultsparams.html">BoxrecResultsParams</a>.<a href="boxrecresultsparams.html#division">division</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L5">boxrec-pages/results/boxrec.results.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L5">boxrec-pages/results/boxrec.results.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecresultsparams.html">BoxrecResultsParams</a>.<a href="boxrecresultsparams.html#offset">offset</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L6">boxrec-pages/results/boxrec.results.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L6">boxrec-pages/results/boxrec.results.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">tv<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.schedule.constants.ts#L4">boxrec-pages/schedule/boxrec.schedule.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.schedule.constants.ts#L4">boxrec-pages/schedule/boxrec.schedule.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecscheduleparamstransformed.html
+++ b/docs/interfaces/boxrecscheduleparamstransformed.html
@@ -102,7 +102,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecresultsparamstransformed.html">BoxrecResultsParamsTransformed</a>.<a href="boxrecresultsparamstransformed.html#c_countrycode_">c[countryCode]</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L10">boxrec-pages/results/boxrec.results.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L10">boxrec-pages/results/boxrec.results.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecresultsparamstransformed.html">BoxrecResultsParamsTransformed</a>.<a href="boxrecresultsparamstransformed.html#c_division_">c[division]</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L11">boxrec-pages/results/boxrec.results.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L11">boxrec-pages/results/boxrec.results.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">c[tv]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/schedule/boxrec.schedule.constants.ts#L8">boxrec-pages/schedule/boxrec.schedule.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/schedule/boxrec.schedule.constants.ts#L8">boxrec-pages/schedule/boxrec.schedule.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecresultsparamstransformed.html">BoxrecResultsParamsTransformed</a>.<a href="boxrecresultsparamstransformed.html#offset">offset</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/results/boxrec.results.constants.ts#L12">boxrec-pages/results/boxrec.results.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/results/boxrec.results.constants.ts#L12">boxrec-pages/results/boxrec.results.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecsearch.html
+++ b/docs/interfaces/boxrecsearch.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">alias<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L40">boxrec-pages/search/boxrec.search.constants.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L40">boxrec-pages/search/boxrec.search.constants.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">career<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L41">boxrec-pages/search/boxrec.search.constants.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L41">boxrec-pages/search/boxrec.search.constants.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L42">boxrec-pages/search/boxrec.search.constants.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L42">boxrec-pages/search/boxrec.search.constants.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#id">id</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L43">boxrec-pages/search/boxrec.search.constants.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L43">boxrec-pages/search/boxrec.search.constants.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">last6<span class="tsd-signature-symbol">:</span> <a href="../enums/winlossdraw.html" class="tsd-signature-type">WinLossDraw</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L44">boxrec-pages/search/boxrec.search.constants.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L44">boxrec-pages/search/boxrec.search.constants.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="boxrecbasic.html">BoxrecBasic</a>.<a href="boxrecbasic.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L27">boxrec-pages/boxrec.constants.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">record<span class="tsd-signature-symbol">:</span> <a href="record.html" class="tsd-signature-type">Record</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L45">boxrec-pages/search/boxrec.search.constants.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L45">boxrec-pages/search/boxrec.search.constants.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">residence<span class="tsd-signature-symbol">:</span> <a href="boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L46">boxrec-pages/search/boxrec.search.constants.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L46">boxrec-pages/search/boxrec.search.constants.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecsearchlocation.html
+++ b/docs/interfaces/boxrecsearchlocation.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<wbr>Country<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L59">boxrec-pages/search/boxrec.search.constants.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L59">boxrec-pages/search/boxrec.search.constants.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<wbr>Locality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L60">boxrec-pages/search/boxrec.search.constants.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L60">boxrec-pages/search/boxrec.search.constants.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<wbr>Region<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L61">boxrec-pages/search/boxrec.search.constants.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L61">boxrec-pages/search/boxrec.search.constants.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">street<wbr>Address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L62">boxrec-pages/search/boxrec.search.constants.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L62">boxrec-pages/search/boxrec.search.constants.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecsearchmetadata.html
+++ b/docs/interfaces/boxrecsearchmetadata.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L50">boxrec-pages/search/boxrec.search.constants.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L50">boxrec-pages/search/boxrec.search.constants.ts:50</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">start<wbr>Date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L53">boxrec-pages/search/boxrec.search.constants.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L53">boxrec-pages/search/boxrec.search.constants.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecsearchoutput.html
+++ b/docs/interfaces/boxrecsearchoutput.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">results<span class="tsd-signature-symbol">:</span> <a href="boxrecsearch.html" class="tsd-signature-type">BoxrecSearch</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.page.search.constants.ts#L4">boxrec-pages/search/boxrec.page.search.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.page.search.constants.ts#L4">boxrec-pages/search/boxrec.page.search.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecsearchparams.html
+++ b/docs/interfaces/boxrecsearchparams.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">first_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L9">boxrec-pages/search/boxrec.search.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L9">boxrec-pages/search/boxrec.search.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">last_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L10">boxrec-pages/search/boxrec.search.constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L10">boxrec-pages/search/boxrec.search.constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">role<span class="tsd-signature-symbol">:</span> <a href="../enums/boxrecrole.html" class="tsd-signature-type">BoxrecRole</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L11">boxrec-pages/search/boxrec.search.constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L11">boxrec-pages/search/boxrec.search.constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <a href="../enums/boxrecstatus.html" class="tsd-signature-type">BoxrecStatus</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L12">boxrec-pages/search/boxrec.search.constants.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L12">boxrec-pages/search/boxrec.search.constants.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecsearchparamstransformed.html
+++ b/docs/interfaces/boxrecsearchparamstransformed.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L32">boxrec-pages/search/boxrec.search.constants.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L32">boxrec-pages/search/boxrec.search.constants.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">pf[first_<wbr>name]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L33">boxrec-pages/search/boxrec.search.constants.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L33">boxrec-pages/search/boxrec.search.constants.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">pf[last_<wbr>name]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L34">boxrec-pages/search/boxrec.search.constants.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L34">boxrec-pages/search/boxrec.search.constants.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">pf[role]<span class="tsd-signature-symbol">:</span> <a href="../enums/boxrecrole.html" class="tsd-signature-type">BoxrecRole</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L35">boxrec-pages/search/boxrec.search.constants.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L35">boxrec-pages/search/boxrec.search.constants.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">pf[status]<span class="tsd-signature-symbol">:</span> <a href="../enums/boxrecstatus.html" class="tsd-signature-type">BoxrecStatus</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/search/boxrec.search.constants.ts#L36">boxrec-pages/search/boxrec.search.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/search/boxrec.search.constants.ts#L36">boxrec-pages/search/boxrec.search.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrectitleoutput.html
+++ b/docs/interfaces/boxrectitleoutput.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">bouts<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpagetitlerow.html" class="tsd-signature-type">BoxrecPageTitleRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.constants.ts#L5">boxrec-pages/title/boxrec.page.title.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.constants.ts#L5">boxrec-pages/title/boxrec.page.title.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">champion<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.constants.ts#L6">boxrec-pages/title/boxrec.page.title.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.constants.ts#L6">boxrec-pages/title/boxrec.page.title.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.constants.ts#L7">boxrec-pages/title/boxrec.page.title.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.constants.ts#L7">boxrec-pages/title/boxrec.page.title.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfBouts<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/title/boxrec.page.title.constants.ts#L8">boxrec-pages/title/boxrec.page.title.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/title/boxrec.page.title.constants.ts#L8">boxrec-pages/title/boxrec.page.title.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrectitles.html
+++ b/docs/interfaces/boxrectitles.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common.constants.ts#L4">boxrec-common-tables/boxrec-common.constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common.constants.ts#L4">boxrec-common-tables/boxrec-common.constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common.constants.ts#L5">boxrec-common-tables/boxrec-common.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common.constants.ts#L5">boxrec-common-tables/boxrec-common.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">supervisor<span class="tsd-signature-symbol">:</span> <a href="boxrecbasic.html" class="tsd-signature-type">BoxrecBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common.constants.ts#L6">boxrec-common-tables/boxrec-common.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common.constants.ts#L6">boxrec-common-tables/boxrec-common.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrectitlesoutput.html
+++ b/docs/interfaces/boxrectitlesoutput.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">bouts<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpagetitlesrow.html" class="tsd-signature-type">BoxrecPageTitlesRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L36">boxrec-pages/titles/boxrec.page.title.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L36">boxrec-pages/titles/boxrec.page.title.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfBouts<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L37">boxrec-pages/titles/boxrec.page.title.constants.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L37">boxrec-pages/titles/boxrec.page.title.constants.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfPages<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L38">boxrec-pages/titles/boxrec.page.title.constants.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L38">boxrec-pages/titles/boxrec.page.title.constants.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrectitlesparams.html
+++ b/docs/interfaces/boxrectitlesparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">bout_<wbr>title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L25">boxrec-pages/titles/boxrec.page.title.constants.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L25">boxrec-pages/titles/boxrec.page.title.constants.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">division<span class="tsd-signature-symbol">:</span> <a href="../enums/weightdivisioncapitalized.html" class="tsd-signature-type">WeightDivisionCapitalized</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L26">boxrec-pages/titles/boxrec.page.title.constants.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L26">boxrec-pages/titles/boxrec.page.title.constants.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrectitlesparamstransformed.html
+++ b/docs/interfaces/boxrectitlesparamstransformed.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">Wc<wbr>X[bout_<wbr>title]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L30">boxrec-pages/titles/boxrec.page.title.constants.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L30">boxrec-pages/titles/boxrec.page.title.constants.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">Wc<wbr>X[division]<span class="tsd-signature-symbol">:</span> <a href="../enums/weightdivisioncapitalized.html" class="tsd-signature-type">WeightDivisionCapitalized</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L31">boxrec-pages/titles/boxrec.page.title.constants.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L31">boxrec-pages/titles/boxrec.page.title.constants.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L32">boxrec-pages/titles/boxrec.page.title.constants.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/titles/boxrec.page.title.constants.ts#L32">boxrec-pages/titles/boxrec.page.title.constants.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecunformattedchampions.html
+++ b/docs/interfaces/boxrecunformattedchampions.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">belt<wbr>Holders<span class="tsd-signature-symbol">:</span> <a href="boxrecbelts.html" class="tsd-signature-type">BoxrecBelts</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L43">boxrec-pages/champions/boxrec.champions.constants.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L43">boxrec-pages/champions/boxrec.champions.constants.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">weight<wbr>Division<span class="tsd-signature-symbol">:</span> <a href="../enums/weightdivision.html" class="tsd-signature-type">WeightDivision</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/champions/boxrec.champions.constants.ts#L44">boxrec-pages/champions/boxrec.champions.constants.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/champions/boxrec.champions.constants.ts#L44">boxrec-pages/champions/boxrec.champions.constants.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecvenueoutput.html
+++ b/docs/interfaces/boxrecvenueoutput.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">events<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpagevenueeventsrow.html" class="tsd-signature-type">BoxrecPageVenueEventsRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L5">boxrec-pages/venue/boxrec.page.venue.constants.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L5">boxrec-pages/venue/boxrec.page.venue.constants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Boxers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L6">boxrec-pages/venue/boxrec.page.venue.constants.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L6">boxrec-pages/venue/boxrec.page.venue.constants.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Managers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L7">boxrec-pages/venue/boxrec.page.venue.constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L7">boxrec-pages/venue/boxrec.page.venue.constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">location<span class="tsd-signature-symbol">:</span> <a href="boxreclocation.html" class="tsd-signature-type">BoxrecLocation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L8">boxrec-pages/venue/boxrec.page.venue.constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L8">boxrec-pages/venue/boxrec.page.venue.constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L9">boxrec-pages/venue/boxrec.page.venue.constants.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/venue/boxrec.page.venue.constants.ts#L9">boxrec-pages/venue/boxrec.page.venue.constants.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/boxrecwatchoutput.html
+++ b/docs/interfaces/boxrecwatchoutput.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">list<span class="tsd-signature-symbol">:</span> <a href="../classes/boxrecpagewatchrow.html" class="tsd-signature-type">BoxrecPageWatchRow</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/watch/boxrec.watch.constants.ts#L13">boxrec-pages/watch/boxrec.watch.constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/watch/boxrec.watch.constants.ts#L13">boxrec-pages/watch/boxrec.watch.constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/linksobj.html
+++ b/docs/interfaces/linksobj.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">class<wbr>Attr<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-links.ts#L6">boxrec-common-tables/boxrec-common-links.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-links.ts#L6">boxrec-common-tables/boxrec-common-links.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">div<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Cheerio</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-links.ts#L7">boxrec-common-tables/boxrec-common-links.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-links.ts#L7">boxrec-common-tables/boxrec-common-links.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">href<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-links.ts#L8">boxrec-common-tables/boxrec-common-links.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-links.ts#L8">boxrec-common-tables/boxrec-common-links.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">href<wbr>Arr<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-common-tables/boxrec-common-links.ts#L9">boxrec-common-tables/boxrec-common-links.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-common-tables/boxrec-common-links.ts#L9">boxrec-common-tables/boxrec-common-links.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/personrequestparams.html
+++ b/docs/interfaces/personrequestparams.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L69">boxrec-pages/profile/boxrec.profile.constants.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L69">boxrec-pages/profile/boxrec.profile.constants.ts:69</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">pdf<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"y"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L70">boxrec-pages/profile/boxrec.profile.constants.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L70">boxrec-pages/profile/boxrec.profile.constants.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">print<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"y"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L71">boxrec-pages/profile/boxrec.profile.constants.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L71">boxrec-pages/profile/boxrec.profile.constants.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">toggle<wbr>Ratings<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"y"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/profile/boxrec.profile.constants.ts#L72">boxrec-pages/profile/boxrec.profile.constants.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/profile/boxrec.profile.constants.ts#L72">boxrec-pages/profile/boxrec.profile.constants.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/record.html
+++ b/docs/interfaces/record.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">draw<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L35">boxrec-pages/boxrec.constants.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L35">boxrec-pages/boxrec.constants.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">loss<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L36">boxrec-pages/boxrec.constants.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L36">boxrec-pages/boxrec.constants.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">win<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/fbc6748/src/boxrec-pages/boxrec.constants.ts#L37">boxrec-pages/boxrec.constants.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/boxing/boxrec/blob/50f5749/src/boxrec-pages/boxrec.constants.ts#L37">boxrec-pages/boxrec.constants.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts
+++ b/src/boxrec-pages/profile/boxrec.page.profile.boxer.ts
@@ -25,7 +25,7 @@ export class BoxrecPageProfileBoxer extends BoxrecPageProfile {
      * @returns {number | null}
      */
     get KOs(): number | null {
-        const ko: string | void = this.parseProfileTableData(BoxrecProfileTable.KOs);
+        const ko: string | void = this.$(".profileWLD tr:nth-child(2) .textWon").text();
 
         if (ko) {
             const kos: number = parseInt(ko, 10);

--- a/src/boxrec-pages/profile/boxrec.page.profile.spec.ts
+++ b/src/boxrec-pages/profile/boxrec.page.profile.spec.ts
@@ -100,7 +100,7 @@ describe("class BoxrecPageProfile", () => {
             });
 
             it("should return the number of KOs/TKOs this boxer has dealt out", () => {
-                expect(outputRJJ.KOs).toBeGreaterThanOrEqual(63);
+                expect(outputRJJ.KOs).toBeGreaterThanOrEqual(47);
             });
 
             it("should return the status of the person", () => {


### PR DESCRIPTION
The profile box has `KOs` but it is percentage.  `KOs` sounds more like
number of KOs and not percentage.  So instead return the number