### PR TITLE
Fix rating returning null

### DIFF
--- a/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts
+++ b/src/boxrec-pages/profile/boxrec.page.profile.boxer.bout.row.ts
@@ -36,7 +36,7 @@ import {BoxrecProfileCommonRow} from "./boxrec.profile.common.row";
     "secondBoxerWeight",
     "titles"
 ])
-@RatingGetter(true)
+@RatingGetter()
 export class BoxrecPageProfileBoxerBoutRow extends BoxrecProfileCommonRow
     implements DateInterface, FirstBoxerWeightInterface,
         MetadataInterface, OutcomeInterface, OutputInterface, RatingInterface {

--- a/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts
+++ b/src/boxrec-pages/profile/boxrec.page.profile.other.common.bout.row.ts
@@ -13,7 +13,7 @@ import {BoxrecProfileCommonRow} from "./boxrec.profile.common.row";
 @FirstBoxerWeightGetter()
 @MetadataGetter()
 @OutcomeGetter(BoxrecCommonTableHeader.result)
-@RatingGetter(true)
+@RatingGetter()
 export class BoxrecPageProfileOtherCommonBoutRow extends BoxrecProfileCommonRow
     implements DateInterface, FirstBoxerWeightInterface, MetadataInterface, OutcomeInterface, RatingInterface {
 

--- a/src/boxrec-pages/ratings/boxrec.page.ratings.active-division.row.ts
+++ b/src/boxrec-pages/ratings/boxrec.page.ratings.active-division.row.ts
@@ -8,7 +8,7 @@ import {BoxrecPageRatingsActiveDivisionRowOutput} from "./boxrec.ratings.constan
 @OutputGetter([
     "age", "hasBoutScheduled", "id", "last6", "name", "points", "rating", "record", "residence", "stance"
 ])
-@RatingGetter(true)
+@RatingGetter()
 export class BoxrecPageRatingsActiveDivisionRow extends BoxrecPageRatingsRow
     implements OutputInterface, RatingInterface {
 

--- a/src/boxrec-pages/schedule/boxrec.page.schedule.spec.ts
+++ b/src/boxrec-pages/schedule/boxrec.page.schedule.spec.ts
@@ -126,6 +126,14 @@ describe("class BoxrecPageSchedule", () => {
 
                     });
 
+                    describe("getter rating", () => {
+
+                        it("should return a value of 0 or greater", () => {
+                            expect(event.bouts[0].rating).toBeGreaterThanOrEqual(0);
+                        });
+
+                    });
+
                 });
 
             });

--- a/src/boxrec-pages/titles/boxrec.page.titles.row.ts
+++ b/src/boxrec-pages/titles/boxrec.page.titles.row.ts
@@ -26,7 +26,7 @@ import {BoxrecPageTitlesRowOutput} from "./boxrec.page.title.constants";
 @OutputGetter(["date", "division", "firstBoxer", "firstBoxerWeight", "links",
     "location", "metadata", "numberOfRounds", "outcome", "rating", "secondBoxer", "secondBoxerWeight",
 ])
-@RatingGetter(true)
+@RatingGetter()
 export class BoxrecPageTitlesRow implements DateInterface, DivisionInterface, FirstBoxerInterface,
     FirstBoxerWeightInterface, MetadataInterface,
     NumberOfRoundsInterface, OutcomeInterface, OutputInterface, RatingInterface {

--- a/src/boxrec.class.spec.e2e.ts
+++ b/src/boxrec.class.spec.e2e.ts
@@ -642,6 +642,14 @@ describe("class Boxrec (E2E)", () => {
                         expect(event.bouts[0].secondBoxer).toBeDefined();
                     });
 
+                    describe("getter rating", () => {
+
+                        it("should return a value of 0 or greater", () => {
+                            expect(event.bouts[0].rating).toBeGreaterThanOrEqual(0);
+                        });
+
+                    });
+
                 });
 
             });

--- a/src/decorators/rating.decorator.ts
+++ b/src/decorators/rating.decorator.ts
@@ -3,16 +3,15 @@ import {BoxrecCommonTableHeader, getColumnDataByColumnHeader} from "../helpers";
 
 /**
  * Adds a getter to the class that returns the rating for this bout
- * @param returnHTML    whether to return HTML or not
  * @constructor
  */
-export function RatingGetter(returnHTML: boolean = false):
+export function RatingGetter():
     (target: any) => void {
     return target => {
         Object.defineProperty(target.prototype, "rating", {
             get(): number | null {
                 return BoxrecCommonTablesColumnsClass.parseRating(getColumnDataByColumnHeader(this.$,
-                    this.headerColumns, BoxrecCommonTableHeader.rating, returnHTML));
+                    this.headerColumns, BoxrecCommonTableHeader.rating, true));
             },
         });
     };


### PR DESCRIPTION
By default the decorator would not parse the HTML when really it should
always parse the HTML regardless