### PR TITLE
Upgrade TypeScript to 3.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ts-jest": "<23.10.0",
     "tslint": "^5.10.0",
     "typedoc": "^0.14.2",
-    "typescript": "^3.6.4",
+    "typescript": "^3.7.0",
     "uglifyjs-folder": "^1.5.1"
   },
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@types/cheerio": "^0.22.7",
     "@types/jest": "^22.1.1",
+    "@types/node": "^12.12.5",
     "@types/request": "^2.47.0",
     "@types/request-promise": "^4.1.41",
     "boxrec-mocks": "^3.0.1",
@@ -39,7 +40,7 @@
     "ts-jest": "<23.10.0",
     "tslint": "^5.10.0",
     "typedoc": "^0.14.2",
-    "typescript": "^3.4.5",
+    "typescript": "^3.6.4",
     "uglifyjs-folder": "^1.5.1"
   },
   "bugs": {

--- a/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts
+++ b/src/boxrec-common-tables/boxrec-common-tables-columns.class.ts
@@ -2,7 +2,7 @@ import * as cheerio from "cheerio";
 import * as querystring from "querystring";
 import {BoxrecBasic, BoxrecJudge, BoxrecLocation, Record, WinLossDraw} from "../boxrec-pages/boxrec.constants";
 import {WeightDivision} from "../boxrec-pages/champions/boxrec.champions.constants";
-import {BoxingBoutOutcome} from "../boxrec-pages/event/boxrec.event.constants";
+import {BoxingBoutOutcome, BoxingBoutOutcomeKeys} from "../boxrec-pages/event/boxrec.event.constants";
 import {convertFractionsToNumber, replaceWithWeight, trimRemoveLineBreaks, whatTypeOfLink} from "../helpers";
 import {BoxrecTitles} from "./boxrec-common.constants";
 
@@ -266,7 +266,7 @@ export abstract class BoxrecCommonTablesColumnsClass {
             outcomeByWayOf = outcomeByWayOf.trim();
 
             if (parseText) {
-                return BoxingBoutOutcome[outcomeByWayOf as keyof typeof BoxingBoutOutcome];
+                return BoxingBoutOutcome[outcomeByWayOf as BoxingBoutOutcomeKeys];
             }
 
             return outcomeByWayOf;

--- a/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts
+++ b/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts
@@ -4,7 +4,7 @@ import {OutputGetter, OutputInterface} from "../../../decorators/output.decorato
 import {convertFractionsToNumber, parseHeight, trimRemoveLineBreaks} from "../../../helpers";
 import {BoxrecBasic, BoxrecJudge, Record, Stance, WinLossDraw} from "../../boxrec.constants";
 import {WeightDivision} from "../../champions/boxrec.champions.constants";
-import {BoxingBoutOutcome} from "../boxrec.event.constants";
+import {BoxingBoutOutcome, BoxingBoutOutcomeKeys} from "../boxrec.event.constants";
 import {BoxrecPageEvent} from "../boxrec.page.event";
 import {
     BoutPageBoutOutcome,
@@ -575,7 +575,7 @@ export class BoxrecPageEventBout extends BoxrecPageEvent implements OutputInterf
 
         // if it finds the key in the enum, we can return it as that type
         if (foundKey) {
-            const outcomeByWayOf: BoxingBoutOutcome = BoxingBoutOutcome[foundKey as keyof typeof BoxingBoutOutcome];
+            const outcomeByWayOf: BoxingBoutOutcome = BoxingBoutOutcome[foundKey as BoxingBoutOutcomeKeys];
 
             return {
                 outcome: WinLossDraw.win,

--- a/src/boxrec-pages/event/boxrec.event.constants.ts
+++ b/src/boxrec-pages/event/boxrec.event.constants.ts
@@ -18,6 +18,8 @@ export enum BoxingBoutOutcome {
     NWS = "newspaper decision",
 }
 
+export type BoxingBoutOutcomeKeys = keyof typeof BoxingBoutOutcome;
+
 export interface BoxrecEventLinks {
     bio: number | null; // this is the wiki link
     bout: number | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,6 +152,11 @@
   version "9.6.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.2.tgz#e49ac1adb458835e95ca6487bc20f916b37aff23"
 
+"@types/node@^12.12.5":
+  version "12.12.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.5.tgz#66103d2eddc543d44a04394abb7be52506d7f290"
+  integrity sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A==
+
 "@types/node@^6.14.4":
   version "6.14.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.14.7.tgz#2173f79d7a61d97d3aad2feeaac7ac69a3df39af"
@@ -6732,10 +6737,10 @@ typescript@3.2.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
-typescript@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
+  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
 uglify-es@^3.1.9:
   version "3.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6737,10 +6737,10 @@ typescript@3.2.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
-typescript@^3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@^3.7.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-es@^3.1.9:
   version "3.3.9"


### PR DESCRIPTION
I was poking around in the codebase, and my editor was configured to use my global typescript installation instead of the package-local version. So I figured I could upgrade while poking around 😄 

I had to add a dev dependency for `@types/node`, otherwise I was getting [this error](https://gist.github.com/sidraval/9a36fa565683fd61675a003bac335f6b) when I ran `yarn run tsc`. Adding a dev dependency for `@types/node` was the recommended solution [here](https://github.com/microsoft/TypeScript/issues/32333).

Hope this is helpful! 

e: Edit to clarify that I'm using Node v10.15.1