### PR TITLE
Bump boxrec-requests which include form-data dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.0.2 (2022-05-22)
+
+### Fixed
+
+-   Bump `boxrec-requests` to 6.0.2, which includes adding `form-data` as a dependency which may be [affecting some users](https://github.com/boxing/boxrec-requests/pull/78)
+
 ## 8.0.1 (2022-05-12)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxrec",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "retrieve information from BoxRec and return it in JSON format",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -54,7 +54,7 @@
     "url": "https://github.com/boxing/boxrec"
   },
   "dependencies": {
-    "boxrec-requests": "6.0.1",
+    "boxrec-requests": "6.0.2",
     "cheerio": "^1.0.0-rc.2",
     "snyk": "^1.685.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,12 +719,13 @@ boxrec-mocks@^3.0.1:
     html-loader "^0.5.5"
     webpack "^4.28.0"
 
-boxrec-requests@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/boxrec-requests/-/boxrec-requests-6.0.1.tgz#882e5c3ffec230a657e44ca19b572f644542e01b"
-  integrity sha512-1qxB7jkBuVTv8ZsjaNw9zC2JDSfwo++XtmQslSMiLCE5EmJ2xXyaDt+YrstIdjjpM8/o6qNxX/hRJXXTO86UwQ==
+boxrec-requests@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/boxrec-requests/-/boxrec-requests-6.0.2.tgz#2fe5f8a134b0055a320e628d12f3aac399ee9c06"
+  integrity sha512-iZu4xscKDZKwzCMPpOqy1b+hYJi7Ho1aOUwODBl1RVk8l6rIsRXKpw7U8kD+LI1LJ7jWbTXCum6BW/yQD1w8mA==
   dependencies:
     cheerio "^1.0.0-rc.3"
+    form-data "^4.0.0"
     node-fetch "2"
     snyk "^1.883.0"
 
@@ -1115,6 +1116,13 @@ color-name@^1.1.1:
 combined-stream@1.0.6, combined-stream@^1.0.6, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz"
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -1937,6 +1945,15 @@ foreach@^2.0.5:
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.1:
   version "2.3.2"


### PR DESCRIPTION
Appears this may be an [issue](https://github.com/boxing/boxrec/issues/286#issuecomment-1128894696) but that being said it is used in `boxrec-requests`