### PR TITLE
Profile bout location was returning null as the selector on BoxRec has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 8.0.4 (2022-04-29)
+## 8.0.5 (2022-06-11)
+
+### Fixed
+
+-   Fix [issue](https://github.com/boxing/boxrec/issues/296) where profile bout location was coming up `null` because the selector had changed.  Selector is more flexible now.
+
+## 8.0.4 (2022-05-29)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boxrec",
-  "version": "8.0.4",
-  "description": "retrieve information from BoxRec and return it in JSON format",
+  "version": "8.0.5",
+  "description": "Retrieve information from BoxRec and return it in JSON format",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/src/__tests__/boxrec.getBoutById.spec.e2e.ts
+++ b/src/__tests__/boxrec.getBoutById.spec.e2e.ts
@@ -110,7 +110,7 @@ describe('method getBoutById', () => {
     describe('getter secondBoxerRating', () => {
 
         it('should return the ranking', () => {
-            expect(caneloKhanBout.secondBoxerRanking).toEqual(jasmine.any(Number));
+            expect(caneloKhanBout.secondBoxerRanking).toEqual(null);
         });
 
     });

--- a/src/__tests__/boxrec.getChampions.spec.e2e.ts
+++ b/src/__tests__/boxrec.getChampions.spec.e2e.ts
@@ -5,7 +5,7 @@ import {logIn, wait} from './helpers';
 
 jest.setTimeout(200000);
 
-// todo skipping as the champions page as changed dramatically
+// todo skipping as the champions page has changed dramatically
 describe.skip('method getChampions', () => {
 
     describe('object champions', () => {

--- a/src/__tests__/boxrec.getEventById.spec.e2e.ts
+++ b/src/__tests__/boxrec.getEventById.spec.e2e.ts
@@ -60,14 +60,17 @@ describe('method getEventById', () => {
         });
 
         it('should return the second boxer\'s last 6', () => {
-            expect(bout.secondBoxerLast6).toEqual([WinLossDraw.win, WinLossDraw.win, WinLossDraw.win, WinLossDraw.win, WinLossDraw.win, WinLossDraw.draw]);
+            expect(bout.secondBoxerLast6).toEqual(
+                [WinLossDraw.win, WinLossDraw.win, WinLossDraw.win,
+                    WinLossDraw.win, WinLossDraw.win, WinLossDraw.draw]);
         });
 
     });
 
     it('should not crash if trying to parse an event with pending/approval header', async () => {
         // to test this it requires an event that is pending approval (https://github.com/boxing/boxrec/issues/290)
-        const response = await Boxrec.getEventById(loggedInCookie, parseInt(process.env.BOUT_PENDING_APPROVAL || '', 10));
+        const response = await Boxrec.getEventById(loggedInCookie,
+            parseInt(process.env.BOUT_PENDING_APPROVAL || '', 10));
         await wait();
         const {bouts} = response;
         expect(bouts[0].firstBoxer.id).toEqual(expect.any(Number));

--- a/src/__tests__/boxrec.getPersonById.spec.e2e.ts
+++ b/src/__tests__/boxrec.getPersonById.spec.e2e.ts
@@ -32,12 +32,18 @@ describe('method getPersonById', () => {
 
         describe('active', () => {
 
+            // Saul Alvarez
             const activeBoxer: number = 348759;
 
             beforeAll(async () => {
-                // Saul Alvarez
                 boxers.set(activeBoxer, await Boxrec.getPersonById(loggedInCookie, activeBoxer, BoxrecRole.proBoxer));
                 await wait();
+            });
+
+            describe('output', () => {
+               it('location should be defined', async() => {
+                   expect(getBoxer(activeBoxer).output.bouts[0].location).toEqual(expect.any(String));
+               });
             });
 
             describe('enrollments', () => {

--- a/src/__tests__/boxrec.getPersonById.spec.e2e.ts
+++ b/src/__tests__/boxrec.getPersonById.spec.e2e.ts
@@ -41,7 +41,7 @@ describe('method getPersonById', () => {
             });
 
             describe('output', () => {
-               it('location should be defined', async() => {
+               it('location should be defined', () => {
                    expect(getBoxer(activeBoxer).output.bouts[0].location).toEqual(expect.any(String));
                });
             });

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -4,7 +4,7 @@ import {Boxrec} from '../boxrec.class';
 
 jest.setTimeout(200000);
 
-export const wait: () => Promise<any> = async () => new Promise((r: any) => setTimeout(r, 0));
+export const wait: () => Promise<any> = async () => new Promise((r: any) => setTimeout(r, 5000));
 
 export const expectId: (id: number | null, expectedId: any) => void = (id: number | null, expectedId: any) =>
     expect(id).toEqual(expectedId);

--- a/src/boxrec-pages/date/boxrec.date.event.ts
+++ b/src/boxrec-pages/date/boxrec.date.event.ts
@@ -1,4 +1,5 @@
 import {BoxrecRole} from 'boxrec-requests';
+import {locationFlagSelector} from '../../helpers';
 import {BoxrecEvent} from '../event/boxrec.event';
 
 /**
@@ -11,7 +12,7 @@ export class BoxrecDateEvent extends BoxrecEvent {
     }
 
     protected parseLocation(): string {
-        return this.$('.flag').parent().html() as string;
+        return this.$(locationFlagSelector).parent().html();
     }
 
     /**

--- a/src/boxrec-pages/date/boxrec.date.event.ts
+++ b/src/boxrec-pages/date/boxrec.date.event.ts
@@ -11,7 +11,7 @@ export class BoxrecDateEvent extends BoxrecEvent {
         return parseInt(this.parseId(), 10);
     }
 
-    protected parseLocation(): string {
+    protected parseLocation(): string | null {
         return this.$(locationFlagSelector).parent().html();
     }
 

--- a/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts
+++ b/src/boxrec-pages/event/bout/boxrec.page.event.bout.ts
@@ -102,6 +102,9 @@ export class BoxrecPageEventBout extends BoxrecPageEvent implements OutputInterf
         return this.parsePoints(false, 1);
     }
 
+    /**
+     * Ranking is not the boxer ranking at the time of the bout but the ranking at this current time
+     */
     get firstBoxerRanking(): number | null {
         return this.parseRankingData(1);
     }
@@ -265,6 +268,9 @@ export class BoxrecPageEventBout extends BoxrecPageEvent implements OutputInterf
         return this.parsePoints(false, 3);
     }
 
+    /**
+     * Ranking is not the boxer ranking at the time of the bout but the ranking at this current time
+     */
     get secondBoxerRanking(): number | null {
         return this.parseRankingData(3);
     }

--- a/src/boxrec-pages/event/boxrec.event.ts
+++ b/src/boxrec-pages/event/boxrec.event.ts
@@ -206,7 +206,7 @@ export abstract class BoxrecEvent extends BoxrecParseBouts implements BoutsInter
     }
 
     // to be overridden by child class
-    protected parseLocation(): string {
+    protected parseLocation(): string | null {
         throw new Error('Needs to be overridden by child class');
     }
 

--- a/src/boxrec.class.spec.e2e.ts
+++ b/src/boxrec.class.spec.e2e.ts
@@ -1,6 +1,6 @@
 import {BoxrecDate, BoxrecFighterOption, BoxrecRole, Country} from 'boxrec-requests';
 import {expectId, expectMatchDate, logIn, wait} from './__tests__/helpers';
-import {WinLossDraw} from './boxrec-pages/boxrec.constants';
+import {BoxrecBoutLocation, WinLossDraw} from "./boxrec-pages/boxrec.constants";
 import {BoxrecPageDate} from './boxrec-pages/date/boxrec.page.date';
 import {BoxrecDateOutput} from './boxrec-pages/date/boxrec.page.date.constants';
 import {BoxrecEventBoutRowOutput} from './boxrec-pages/event/boxrec.event.constants';
@@ -213,6 +213,30 @@ describe('class Boxrec (E2E)', () => {
 
                             });
 
+                        });
+
+                    });
+
+                    describe('getter location', () => {
+
+                        let location: BoxrecBoutLocation;
+
+                        beforeAll(() => { location = sept282019.events[0].location });
+
+                        it('should return the country', () => {
+                            expect(location.location.country.id).toBe('AL');
+                        });
+
+                        it('should return the region', () => {
+                            expect(location.location.region.id).toBe(null);
+                        });
+
+                        it('should return the city', () => {
+                            expect(location.location.town.id).toBe(22960);
+                        });
+
+                        it('it should return the venue', () => {
+                            expect(location.venue.id).toBe(219697);
                         });
 
                     });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -223,7 +223,7 @@ export function getHeaderColumnText(tableEl: Cheerio, theadNumber: number = 1): 
                     tableColumns = tableHeaderRow.siblings('tbody').eq(0).find(`tr:nth-child(2) td`);
                 }
 
-                const tbodyColumnEl =  tableColumns.eq(i);
+                const tbodyColumnEl = tableColumns.eq(i);
 
                 if (!tbodyColumnEl.length) {
                     throw new Error('Could not get table body element');
@@ -253,7 +253,7 @@ export function getHeaderColumnText(tableEl: Cheerio, theadNumber: number = 1): 
                 }
 
                 // check if location (on profiles, it doesn't have a location header text)
-                if (tbodyColumnEl.find('.flag').length || tbodyColumnEl.find('.flag-icon').length) {
+                if (tbodyColumnEl.find(locationFlagSelector).length) {
                     headersArr.push(BoxrecCommonTableHeader.location);
                     return;
                 }
@@ -303,6 +303,8 @@ export function getHeaderColumnText(tableEl: Cheerio, theadNumber: number = 1): 
 
     return headersArr;
 }
+
+export const locationFlagSelector = '*[class*="flag"]';
 
 // the following regex assumes the string is always in the same format
 // `region` and `town` are wrapped with a conditional statement

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -253,7 +253,7 @@ export function getHeaderColumnText(tableEl: Cheerio, theadNumber: number = 1): 
                 }
 
                 // check if location (on profiles, it doesn't have a location header text)
-                if (tbodyColumnEl.find('.flag').length) {
+                if (tbodyColumnEl.find('.flag').length || tbodyColumnEl.find('.flag-icon').length) {
                     headersArr.push(BoxrecCommonTableHeader.location);
                     return;
                 }


### PR DESCRIPTION
The selector used before was `.flag` and has now become `.flag-icon`.  To prevent future breakages the selector now is less strict and only looks for a class name that contains "flag".

Fixes #296 